### PR TITLE
feat: add simple coding agent example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,8 @@ Guidance for agents working in this repository.
 
 ## Project Shape
 
-This is a Rust workspace for the `ai` crate in `crates/ai`.
+This is a Rust workspace with the `ai` crate in `crates/ai` and example
+packages under `examples/`.
 
 The crate provides:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1153,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1177,15 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple-coding-agent"
+version = "0.1.0"
+dependencies = [
+ "ai",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "slab"
@@ -1278,6 +1307,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 resolver = "2"
 
 members = [
-    "crates/*"
+    "crates/*",
+    "examples/*",
 ]
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ OpenRouter image generation. Use `providers::openai::builder()` for
 OpenAI-compatible endpoints such as llama.cpp, MLX, Ollama, vLLM, and Azure
 Foundry.
 
+### Simple Coding Agent
+
+See [examples/simple-coding-agent](examples/simple-coding-agent/README.md) for a tiny interactive coding-agent example with one `bash` tool.
+
 ### Complete
 
 ```rust

--- a/crates/ai/README.md
+++ b/crates/ai/README.md
@@ -235,7 +235,7 @@ async fn main() -> Result<()> {
                 .base_url("http://localhost:11434/v1")
                 .chat_completions()
                 .build()?;
-            (Box::new(local), "gemma3")
+            (Box::new(local), "gemma4:12b")
         };
 
     let model = provider.model(model_id).build()?;

--- a/crates/ai/src/providers/openai.rs
+++ b/crates/ai/src/providers/openai.rs
@@ -344,7 +344,7 @@ mod tests {
             .chat_completions()
             .build()
             .expect("provider");
-        let model = openai.model("gemma3").build().expect("model");
+        let model = openai.model("gemma4:12b").build().expect("model");
 
         let stream = crate::stream_simple(model, Context::default(), None);
 
@@ -360,7 +360,7 @@ mod tests {
             .chat_completions()
             .build()
             .expect("provider");
-        let model = openai.model("gemma3").build().expect("model");
+        let model = openai.model("gemma4:12b").build().expect("model");
 
         let stream = crate::stream_simple(model, Context::default(), None);
 
@@ -376,7 +376,7 @@ mod tests {
             .chat_completions()
             .build()
             .expect("provider");
-        let model = openai.model("gemma3").build().expect("model");
+        let model = openai.model("gemma4:12b").build().expect("model");
 
         let stream = crate::stream_simple(model, Context::default(), None);
 

--- a/crates/ai/src/utils/overflow.rs
+++ b/crates/ai/src/utils/overflow.rs
@@ -103,7 +103,7 @@ mod tests {
             content: Vec::new(),
             api: "openai-completions".to_string(),
             provider: "ollama".to_string(),
-            model: "qwen3.5:35b".to_string(),
+            model: "gemma4:12b".to_string(),
             response_model: None,
             response_id: None,
             diagnostics: Vec::new(),

--- a/examples/simple-coding-agent/Cargo.toml
+++ b/examples/simple-coding-agent/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "simple-coding-agent"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+ai.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["io-std", "process"] }

--- a/examples/simple-coding-agent/README.md
+++ b/examples/simple-coding-agent/README.md
@@ -1,0 +1,24 @@
+# simple-coding-agent
+
+A tiny interactive coding agent backed by the `ai` crate. It exposes one tool:
+`bash`.
+
+Run from the workspace root:
+
+```bash
+cargo run -p simple-coding-agent
+```
+
+For Ollama:
+
+```bash
+ollama pull gemma4:12b
+OPENAI_BASE_URL=http://localhost:11434/v1 \
+OPENAI_MODEL=gemma4:12b \
+cargo run -p simple-coding-agent
+```
+
+Commands inside the REPL:
+
+- `/clear`: reset conversation context.
+- `/exit` or `/quit`: exit.

--- a/examples/simple-coding-agent/src/main.rs
+++ b/examples/simple-coding-agent/src/main.rs
@@ -149,6 +149,8 @@ fn build_bash_tool() -> Result<DynAgentTool> {
                 .and_then(Value::as_str)
                 .ok_or_else(|| AgentError::Other("missing string argument: command".to_string()))?;
 
+            // For a production agent, add a timeout and cap output before
+            // returning stdout/stderr to the model.
             let output = Command::new("bash")
                 .arg("-lc")
                 .arg(command)

--- a/examples/simple-coding-agent/src/main.rs
+++ b/examples/simple-coding-agent/src/main.rs
@@ -84,8 +84,10 @@ fn build_agent() -> Result<Agent> {
     let cwd = env::current_dir()?;
     let base_url = env::var("OPENAI_BASE_URL").ok();
     let model_id = env::var("OPENAI_MODEL").unwrap_or_else(|_| "gpt-5.5".to_string());
+    let api_key = env::var("OPENAI_API_KEY").ok();
     let openai = match base_url.as_deref() {
         Some(base_url) => openai::builder()
+            .api_key(api_key.as_deref())
             .base_url(base_url)
             .chat_completions()
             .build()?,

--- a/examples/simple-coding-agent/src/main.rs
+++ b/examples/simple-coding-agent/src/main.rs
@@ -137,7 +137,7 @@ fn build_bash_tool() -> Result<DynAgentTool> {
             "properties": {
                 "command": {
                     "type": "string",
-                    "description": "The bash command to run in the agent process current working directory."
+                    "description": "The bash command to run in the agent process's current working directory."
                 }
             },
             "required": ["command"],

--- a/examples/simple-coding-agent/src/main.rs
+++ b/examples/simple-coding-agent/src/main.rs
@@ -1,0 +1,168 @@
+use std::env;
+use std::io::Write;
+
+use ai::{
+    Agent, AgentError, AgentEvent, AgentOptions, AgentToolBuilder, AgentToolResult,
+    AssistantMessageEvent, DynAgentTool, Result, providers::openai,
+};
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let agent = build_agent()?;
+
+    let _subscription = agent.subscribe(|event, _token| async move {
+        match event {
+            AgentEvent::MessageUpdate {
+                assistant_message_event:
+                    AssistantMessageEvent::TextDelta { delta, .. }
+                    | AssistantMessageEvent::ThinkingDelta { delta, .. },
+                ..
+            } => {
+                print!("{delta}");
+                let _ = std::io::stdout().flush();
+            }
+            AgentEvent::MessageUpdate {
+                assistant_message_event: AssistantMessageEvent::Error { .. },
+                ..
+            } => {
+                eprintln!("\nerror: assistant stream failed");
+            }
+            AgentEvent::ToolExecutionStart {
+                tool_name, args, ..
+            } => {
+                println!("\n\n{tool_name}({args})");
+            }
+            AgentEvent::ToolExecutionEnd {
+                tool_name,
+                is_error,
+                ..
+            } => {
+                println!("{tool_name} {}", if is_error { "error" } else { "done" });
+            }
+            _ => {}
+        }
+        Ok(())
+    });
+
+    let stdin = BufReader::new(tokio::io::stdin());
+    let mut lines = stdin.lines();
+    loop {
+        print!("\n> ");
+        let _ = std::io::stdout().flush();
+
+        let Some(line) = lines.next_line().await? else {
+            break;
+        };
+        let prompt = line.trim();
+        if prompt.is_empty() {
+            continue;
+        }
+
+        match prompt {
+            "/exit" | "/quit" => break,
+            "/clear" => {
+                agent.reset().await;
+                println!("context cleared");
+            }
+            _ => {
+                if let Err(error) = agent.prompt_text(prompt, Vec::new()).await {
+                    eprintln!("\nerror: {error}");
+                }
+                println!();
+            }
+        }
+    }
+
+    println!();
+    Ok(())
+}
+
+fn build_agent() -> Result<Agent> {
+    let cwd = env::current_dir()?;
+    let base_url = env::var("OPENAI_BASE_URL").ok();
+    let model_id = env::var("OPENAI_MODEL").unwrap_or_else(|_| "gpt-5.5".to_string());
+    let openai = match base_url.as_deref() {
+        Some(base_url) => openai::builder()
+            .base_url(base_url)
+            .chat_completions()
+            .build()?,
+        None => openai::from_env()?,
+    };
+    let model = openai.model(&model_id).build()?;
+
+    let system_prompt = format!(
+        r#"You are an expert coding assistant operating inside simple-coding-agent, a minimal coding agent harness.
+
+Available tools:
+- bash: Run shell commands in the current working directory
+
+Guidelines:
+- Use bash for file operations like ls, rg, find
+- Be concise in your responses
+- Show file paths clearly when working with files
+- Do not run destructive commands unless the user explicitly asks.
+
+Current working directory: {}"#,
+        cwd.display()
+    );
+
+    let agent = Agent::new(
+        AgentOptions::builder(model)
+            .system_prompt(system_prompt)
+            .tool(build_bash_tool()?)
+            .build(),
+    );
+
+    println!("simple coding agent example powered by ai.rs");
+    println!("model: {model_id}");
+    println!(
+        "base URL: {}",
+        base_url.as_deref().unwrap_or("OpenAI default")
+    );
+    println!("type a prompt, /clear to reset context, or /exit to quit");
+
+    Ok(agent)
+}
+
+fn build_bash_tool() -> Result<DynAgentTool> {
+    AgentToolBuilder::new("bash")
+        .description(
+            "Run a bash command in the current working directory and return stdout, stderr, and exit status.",
+        )
+        .parameters(json!({
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "The bash command to run in the agent process current working directory."
+                }
+            },
+            "required": ["command"],
+            "additionalProperties": false
+        }))
+        .execute(|args| async move {
+            let command = args
+                .get("command")
+                .and_then(Value::as_str)
+                .ok_or_else(|| AgentError::Other("missing string argument: command".to_string()))?;
+
+            let output = Command::new("bash")
+                .arg("-lc")
+                .arg(command)
+                .output()
+                .await
+                .map_err(|error| AgentError::Other(format!("failed to run bash: {error}")))?;
+
+            let mut text = format!("exit status: {}\n", output.status);
+            text.push_str("\nstdout:\n");
+            text.push_str(&String::from_utf8_lossy(&output.stdout));
+            text.push_str("\n\nstderr:\n");
+            text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+            Ok(AgentToolResult::text(text))
+        })
+        .build()
+}


### PR DESCRIPTION
## Summary
- add a simple-coding-agent workspace example with a bash-only interactive agent
- document the example from the root README and include Ollama setup in the example README
- update local model examples to use gemma4:12b

## Checks
- cargo fmt --all --check
- cargo check -p simple-coding-agent
- cargo check --workspace --all-targets