### PR TITLE
fix: support Copilot login in simple agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .claude/
+.env

--- a/crates/ai/src/providers/github_copilot.rs
+++ b/crates/ai/src/providers/github_copilot.rs
@@ -4,6 +4,7 @@ use crate::env_api_keys::{KnownProvider, get_env_api_key};
 use crate::event_stream::AssistantEventStream;
 use crate::oauth::{GitHubCopilotOAuthProvider, OAuthApiKey, OAuthCredentials};
 use crate::provider::{LanguageModelApi, ModelBuilder, Provider, ProviderCapabilities};
+use crate::providers::github_copilot_headers::copilot_static_headers;
 use crate::providers::{anthropic, openai_completions, openai_responses, simple_options};
 use crate::types::{Context, Model, ModelInput, SimpleStreamOptions, StreamOptions};
 use crate::{Error, Result};
@@ -80,6 +81,7 @@ impl Provider for GitHubCopilot {
             .unwrap_or_else(|| DEFAULT_BASE_URL.to_string());
         ModelBuilder::new(&self.provider_id, id, runtime)
             .base_url(base_url)
+            .headers(copilot_static_headers())
             .input(vec![ModelInput::Text, ModelInput::Image])
             .context_window(1_000_000)
             .max_tokens(16_384)
@@ -279,7 +281,17 @@ mod tests {
         assert_eq!(model.provider_id(), "github-copilot");
         assert_eq!(model.api_id(), "openai-responses");
         assert_eq!(model.base_url, DEFAULT_BASE_URL);
-        assert!(model.headers.is_empty());
+        assert_eq!(
+            model.headers.get("Editor-Version").map(String::as_str),
+            Some("vscode/1.107.0")
+        );
+        assert_eq!(
+            model
+                .headers
+                .get("Copilot-Integration-Id")
+                .map(String::as_str),
+            Some("vscode-chat")
+        );
     }
 
     #[test]

--- a/crates/ai/src/providers/github_copilot_headers.rs
+++ b/crates/ai/src/providers/github_copilot_headers.rs
@@ -2,6 +2,24 @@ use std::collections::HashMap;
 
 use crate::types::{Message, ToolResultContent, UserContent, UserMessageContent};
 
+pub(super) fn copilot_static_headers() -> HashMap<String, String> {
+    HashMap::from([
+        (
+            "User-Agent".to_string(),
+            "GitHubCopilotChat/0.35.0".to_string(),
+        ),
+        ("Editor-Version".to_string(), "vscode/1.107.0".to_string()),
+        (
+            "Editor-Plugin-Version".to_string(),
+            "copilot-chat/0.35.0".to_string(),
+        ),
+        (
+            "Copilot-Integration-Id".to_string(),
+            "vscode-chat".to_string(),
+        ),
+    ])
+}
+
 pub fn infer_copilot_initiator(messages: &[Message]) -> &'static str {
     match messages
         .iter()
@@ -165,6 +183,28 @@ mod tests {
         assert_eq!(
             headers.get("Copilot-Vision-Request").map(String::as_str),
             Some("true")
+        );
+    }
+
+    #[test]
+    fn builds_static_headers() {
+        let headers = copilot_static_headers();
+
+        assert_eq!(
+            headers.get("User-Agent").map(String::as_str),
+            Some("GitHubCopilotChat/0.35.0")
+        );
+        assert_eq!(
+            headers.get("Editor-Version").map(String::as_str),
+            Some("vscode/1.107.0")
+        );
+        assert_eq!(
+            headers.get("Editor-Plugin-Version").map(String::as_str),
+            Some("copilot-chat/0.35.0")
+        );
+        assert_eq!(
+            headers.get("Copilot-Integration-Id").map(String::as_str),
+            Some("vscode-chat")
         );
     }
 }

--- a/examples/simple-coding-agent/README.md
+++ b/examples/simple-coding-agent/README.md
@@ -21,4 +21,11 @@ cargo run -p simple-coding-agent
 Commands inside the REPL:
 
 - `/clear`: reset conversation context.
+- `/model [name]`: show the current model, or switch models on the active
+  provider while preserving conversation context.
+- `/login`: log into GitHub Copilot with the device-code flow and switch the
+  agent to Copilot while preserving conversation context. Set `COPILOT_MODEL` to
+  override the default `gpt-5.5` model.
+- `/login <enterprise-domain>`: log into GitHub Copilot for a GitHub Enterprise
+  domain.
 - `/exit` or `/quit`: exit.

--- a/examples/simple-coding-agent/src/main.rs
+++ b/examples/simple-coding-agent/src/main.rs
@@ -3,7 +3,9 @@ use std::io::Write;
 
 use ai::{
     Agent, AgentError, AgentEvent, AgentOptions, AgentToolBuilder, AgentToolResult,
-    AssistantMessageEvent, DynAgentTool, Result, providers::openai,
+    AssistantContent, AssistantMessage, AssistantMessageEvent, DynAgentTool, Message, Model,
+    OAuthLoginCallbacks, Result,
+    providers::{github_copilot, openai},
 };
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -11,7 +13,7 @@ use tokio::process::Command;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let agent = build_agent()?;
+    let (agent, mut active_provider) = build_agent()?;
 
     let _subscription = agent.subscribe(|event, _token| async move {
         match event {
@@ -25,10 +27,31 @@ async fn main() -> Result<()> {
                 let _ = std::io::stdout().flush();
             }
             AgentEvent::MessageUpdate {
-                assistant_message_event: AssistantMessageEvent::Error { .. },
+                assistant_message_event: AssistantMessageEvent::Error { error, .. },
                 ..
             } => {
-                eprintln!("\nerror: assistant stream failed");
+                eprintln!(
+                    "\nerror: {}",
+                    error
+                        .error_message
+                        .as_deref()
+                        .unwrap_or("assistant stream failed")
+                );
+            }
+            AgentEvent::MessageEnd { message } => {
+                if let Message::Assistant(message) = message {
+                    if let Some(error) = &message.error_message {
+                        eprintln!(
+                            "\nerror from {} ({}, {}): {error}",
+                            message.model, message.provider, message.api
+                        );
+                    } else if assistant_visible_content(&message).trim().is_empty() {
+                        eprintln!(
+                            "\nwarning: empty response from {} ({}, {})",
+                            message.model, message.provider, message.api
+                        );
+                    }
+                }
             }
             AgentEvent::ToolExecutionStart {
                 tool_name, args, ..
@@ -61,11 +84,41 @@ async fn main() -> Result<()> {
             continue;
         }
 
-        match prompt {
-            "/exit" | "/quit" => break,
-            "/clear" => {
+        let slash_command = prompt
+            .strip_prefix('/')
+            .map(|command| command.trim_start_matches('/'));
+
+        match slash_command {
+            Some("exit" | "quit") => break,
+            Some("clear") => {
                 agent.reset().await;
                 println!("context cleared");
+            }
+            Some(command) if command == "model" || command.starts_with("model ") => {
+                let model_id = command.strip_prefix("model").map(str::trim).unwrap_or("");
+                if model_id.is_empty() {
+                    let model = agent.state().await.model;
+                    println!("model: {} ({})", model.id, model.provider);
+                } else {
+                    match switch_model(&agent, &active_provider, model_id).await {
+                        Ok(provider) => println!("switched to {model_id} ({provider})"),
+                        Err(error) => eprintln!("\nerror: {error}"),
+                    }
+                }
+            }
+            Some(command) if command == "login" || command.starts_with("login ") => {
+                let enterprise_domain = command
+                    .strip_prefix("login")
+                    .map(str::trim)
+                    .filter(|domain| !domain.is_empty())
+                    .map(str::to_string);
+                match login_github_copilot_and_swap(&agent, enterprise_domain).await {
+                    Ok((model_id, provider)) => {
+                        active_provider = provider;
+                        println!("logged into GitHub Copilot; switched to {model_id}");
+                    }
+                    Err(error) => eprintln!("\nerror: {error}"),
+                }
             }
             _ => {
                 if let Err(error) = agent.prompt_text(prompt, Vec::new()).await {
@@ -80,20 +133,12 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn build_agent() -> Result<Agent> {
+fn build_agent() -> Result<(Agent, ActiveProvider)> {
     let cwd = env::current_dir()?;
     let base_url = env::var("OPENAI_BASE_URL").ok();
     let model_id = env::var("OPENAI_MODEL").unwrap_or_else(|_| "gpt-5.5".to_string());
-    let api_key = env::var("OPENAI_API_KEY").ok();
-    let openai = match base_url.as_deref() {
-        Some(base_url) => openai::builder()
-            .api_key(api_key.as_deref())
-            .base_url(base_url)
-            .chat_completions()
-            .build()?,
-        None => openai::from_env()?,
-    };
-    let model = openai.model(&model_id).build()?;
+    let provider = ActiveProvider::OpenAi(build_openai_provider(base_url.as_deref())?);
+    let model = provider.model(&model_id)?;
 
     let system_prompt = format!(
         r#"You are an expert coding assistant operating inside simple-coding-agent, a minimal coding agent harness.
@@ -124,9 +169,11 @@ Current working directory: {}"#,
         "base URL: {}",
         base_url.as_deref().unwrap_or("OpenAI default")
     );
-    println!("type a prompt, /clear to reset context, or /exit to quit");
+    println!(
+        "type a prompt, /model [name] to view or switch models on the active provider, /login to use Copilot, /clear to reset context, or /exit to quit"
+    );
 
-    Ok(agent)
+    Ok((agent, provider))
 }
 
 fn build_bash_tool() -> Result<DynAgentTool> {
@@ -169,4 +216,95 @@ fn build_bash_tool() -> Result<DynAgentTool> {
             Ok(AgentToolResult::text(text))
         })
         .build()
+}
+
+#[derive(Clone)]
+enum ActiveProvider {
+    OpenAi(openai::OpenAi),
+    GitHubCopilot(github_copilot::GitHubCopilot),
+}
+
+impl ActiveProvider {
+    fn id(&self) -> &'static str {
+        match self {
+            Self::OpenAi(_) => "openai",
+            Self::GitHubCopilot(_) => "github-copilot",
+        }
+    }
+
+    fn model(&self, model_id: &str) -> Result<Model> {
+        match self {
+            Self::OpenAi(provider) => provider.model(model_id).build(),
+            Self::GitHubCopilot(provider) => provider.model(model_id).build(),
+        }
+    }
+}
+
+fn build_openai_provider(base_url: Option<&str>) -> Result<openai::OpenAi> {
+    let api_key = env::var("OPENAI_API_KEY").ok();
+    match base_url {
+        Some(base_url) => openai::builder()
+            .api_key(api_key.as_deref())
+            .base_url(base_url)
+            .chat_completions()
+            .build(),
+        None => openai::from_env(),
+    }
+}
+
+async fn switch_model(agent: &Agent, provider: &ActiveProvider, model_id: &str) -> Result<String> {
+    let model = provider.model(model_id)?;
+    let provider_id = provider.id().to_string();
+
+    agent.set_model(model).await;
+
+    Ok(provider_id)
+}
+
+async fn login_github_copilot_and_swap(
+    agent: &Agent,
+    enterprise_domain: Option<String>,
+) -> Result<(String, ActiveProvider)> {
+    let callbacks = OAuthLoginCallbacks::builder()
+        .on_prompt(move |_| {
+            let enterprise_domain = enterprise_domain.clone().unwrap_or_default();
+            async move { Ok(enterprise_domain) }
+        })
+        .on_device_code(|info| {
+            println!(
+                "Open {} and enter code {}",
+                info.verification_uri, info.user_code
+            );
+            if let Some(expires_in_seconds) = info.expires_in_seconds {
+                println!("code expires in {expires_in_seconds} seconds");
+            }
+        })
+        .on_progress(|message| println!("{message}"))
+        .build();
+
+    let credentials = github_copilot::oauth().login(callbacks).await?;
+    let model_id = env::var("COPILOT_MODEL").unwrap_or_else(|_| "gpt-5.5".to_string());
+    let base_url = github_copilot::base_url_for_credentials(&credentials);
+    let copilot = github_copilot::builder()
+        .api_key(credentials.access)
+        .base_url(base_url)
+        .build()?;
+    let provider = ActiveProvider::GitHubCopilot(copilot);
+    let model = provider.model(&model_id)?;
+
+    agent.set_model(model).await;
+
+    Ok((model_id, provider))
+}
+
+fn assistant_visible_content(message: &AssistantMessage) -> String {
+    message
+        .content
+        .iter()
+        .filter_map(|content| match content {
+            AssistantContent::Text(text) => Some(text.text.as_str()),
+            AssistantContent::Thinking(thinking) => Some(thinking.thinking.as_str()),
+            AssistantContent::ToolCall(_) => Some("<tool_call>"),
+        })
+        .collect()
 }


### PR DESCRIPTION
## Summary
- add /model and /login commands to the simple coding agent example
- attach Copilot IDE headers required by GitHub Copilot auth
- surface empty/error assistant responses in the example loop

## Verification
- mise run fmt
- cargo check -p simple-coding-agent
- cargo test -p ai providers::github_copilot --lib