### PR TITLE
refactor(oauth): dedupe shared HTTP boilerplate into helpers

### DIFF
--- a/crates/ai/src/oauth/anthropic.rs
+++ b/crates/ai/src/oauth/anthropic.rs
@@ -538,21 +538,19 @@ async fn exchange_anthropic_authorization_code_at(
     verifier: &str,
     redirect_uri: &str,
 ) -> Result<OAuthCredentials> {
-    let response = client
-        .post(token_url)
-        .header("Accept", "application/json")
-        .timeout(Duration::from_millis(ANTHROPIC_OAUTH_TOKEN_TIMEOUT_MS))
-        .json(&serde_json::json!({
+    post_anthropic_token_request(
+        client,
+        token_url,
+        serde_json::json!({
             "grant_type": "authorization_code",
             "client_id": ANTHROPIC_CLIENT_ID,
             "code": code,
             "state": state,
             "redirect_uri": redirect_uri,
             "code_verifier": verifier,
-        }))
-        .send()
-        .await?;
-    anthropic_credentials_from_response(response).await
+        }),
+    )
+    .await
 }
 
 async fn refresh_anthropic_token_at(
@@ -560,15 +558,30 @@ async fn refresh_anthropic_token_at(
     token_url: &str,
     refresh_token: &str,
 ) -> Result<OAuthCredentials> {
+    post_anthropic_token_request(
+        client,
+        token_url,
+        serde_json::json!({
+            "grant_type": "refresh_token",
+            "client_id": ANTHROPIC_CLIENT_ID,
+            "refresh_token": refresh_token,
+        }),
+    )
+    .await
+}
+
+/// POSTs a JSON body to an Anthropic OAuth token endpoint with the shared
+/// headers and timeout, mapping the response into credentials.
+async fn post_anthropic_token_request(
+    client: &reqwest::Client,
+    token_url: &str,
+    body: serde_json::Value,
+) -> Result<OAuthCredentials> {
     let response = client
         .post(token_url)
         .header("Accept", "application/json")
         .timeout(Duration::from_millis(ANTHROPIC_OAUTH_TOKEN_TIMEOUT_MS))
-        .json(&serde_json::json!({
-            "grant_type": "refresh_token",
-            "client_id": ANTHROPIC_CLIENT_ID,
-            "refresh_token": refresh_token,
-        }))
+        .json(&body)
         .send()
         .await?;
     anthropic_credentials_from_response(response).await
@@ -577,12 +590,7 @@ async fn refresh_anthropic_token_at(
 async fn anthropic_credentials_from_response(
     response: reqwest::Response,
 ) -> Result<OAuthCredentials> {
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        return Err(Error::ApiStatus { status, body });
-    }
-
+    let response = error_for_status(response).await?;
     let token = response.json::<AnthropicTokenResponse>().await?;
     Ok(anthropic_credentials_from_token(token))
 }

--- a/crates/ai/src/oauth/github_copilot.rs
+++ b/crates/ai/src/oauth/github_copilot.rs
@@ -11,6 +11,7 @@ use crate::{Error, Result};
 use super::*;
 
 const GITHUB_COPILOT_CLIENT_ID: &str = "Iv1.b507a08c87ecfe98";
+const GITHUB_COPILOT_USER_AGENT: &str = "GitHubCopilotChat/0.35.0";
 
 const COPILOT_TOKEN_EXPIRY_SKEW_MS: u64 = 5 * 60 * 1000;
 
@@ -154,6 +155,25 @@ fn is_github_auth_error(error: &Error) -> bool {
     matches!(error, Error::ApiStatus { status, .. } if matches!(status.as_u16(), 401 | 403))
 }
 
+/// POSTs `fields` as `application/x-www-form-urlencoded` to a GitHub OAuth
+/// endpoint with the client headers Copilot expects, returning the checked
+/// response. Shared by the device-code, token-poll, and refresh-grant calls.
+async fn github_oauth_form_post(
+    client: &reqwest::Client,
+    url: &str,
+    fields: &[(&str, &str)],
+) -> Result<reqwest::Response> {
+    let response = client
+        .post(url)
+        .header("Accept", "application/json")
+        .header("User-Agent", GITHUB_COPILOT_USER_AGENT)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(form_body(fields))
+        .send()
+        .await?;
+    error_for_status(response).await
+}
+
 /// Mints a short-lived Copilot API token from a GitHub user access token.
 async fn mint_copilot_token(
     github_access_token: &str,
@@ -169,12 +189,7 @@ async fn mint_copilot_token(
         .headers(copilot_headers(Some(github_access_token))?)
         .send()
         .await?;
-
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        return Err(Error::ApiStatus { status, body });
-    }
+    let response = error_for_status(response).await?;
 
     parse_copilot_token_response(response.json::<Value>().await?)
 }
@@ -278,24 +293,16 @@ async fn refresh_github_user_token_at(
     access_token_url: &str,
     refresh_token: &str,
 ) -> Result<GithubUserToken> {
-    let response = client
-        .post(access_token_url)
-        .header("Accept", "application/json")
-        .header("User-Agent", "GitHubCopilotChat/0.35.0")
-        .header("Content-Type", "application/x-www-form-urlencoded")
-        .body(form_body(&[
+    let response = github_oauth_form_post(
+        client,
+        access_token_url,
+        &[
             ("client_id", GITHUB_COPILOT_CLIENT_ID),
             ("grant_type", "refresh_token"),
             ("refresh_token", refresh_token),
-        ]))
-        .send()
-        .await?;
-
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        return Err(Error::ApiStatus { status, body });
-    }
+        ],
+    )
+    .await?;
 
     match parse_device_token_response(response.json::<Value>().await?) {
         OAuthDeviceCodePollResult::Complete(token) => Ok(token),
@@ -377,22 +384,15 @@ pub fn modify_github_copilot_models(
 async fn start_github_device_flow(domain: &str) -> Result<DeviceCodeResponse> {
     let urls = GitHubCopilotUrls::new(domain);
     let client = reqwest::Client::new();
-    let response = client
-        .post(urls.device_code_url)
-        .header("Accept", "application/json")
-        .header("User-Agent", "GitHubCopilotChat/0.35.0")
-        .header("Content-Type", "application/x-www-form-urlencoded")
-        .body(form_body(&[
+    let response = github_oauth_form_post(
+        &client,
+        &urls.device_code_url,
+        &[
             ("client_id", GITHUB_COPILOT_CLIENT_ID),
             ("scope", "read:user"),
-        ]))
-        .send()
-        .await?;
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        return Err(Error::ApiStatus { status, body });
-    }
+        ],
+    )
+    .await?;
     let device = response.json::<DeviceCodeResponse>().await?;
     if device.device_code.is_empty()
         || device.user_code.is_empty()
@@ -422,23 +422,16 @@ async fn poll_for_github_access_token(
             let access_token_url = urls.access_token_url.clone();
             let device_code = device.device_code.clone();
             async move {
-                let response = client
-                    .post(access_token_url)
-                    .header("Accept", "application/json")
-                    .header("User-Agent", "GitHubCopilotChat/0.35.0")
-                    .header("Content-Type", "application/x-www-form-urlencoded")
-                    .body(form_body(&[
+                let response = github_oauth_form_post(
+                    &client,
+                    &access_token_url,
+                    &[
                         ("client_id", GITHUB_COPILOT_CLIENT_ID),
                         ("device_code", device_code.as_str()),
                         ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
-                    ]))
-                    .send()
-                    .await?;
-                if !response.status().is_success() {
-                    let status = response.status();
-                    let body = response.text().await.unwrap_or_default();
-                    return Err(Error::ApiStatus { status, body });
-                }
+                    ],
+                )
+                .await?;
                 Ok(parse_device_token_response(response.json::<Value>().await?))
             }
         },
@@ -561,7 +554,7 @@ fn copilot_headers(refresh_token: Option<&str>) -> Result<reqwest::header::Heade
     );
     headers.insert(
         "User-Agent",
-        reqwest::header::HeaderValue::from_static("GitHubCopilotChat/0.35.0"),
+        reqwest::header::HeaderValue::from_static(GITHUB_COPILOT_USER_AGENT),
     );
     headers.insert(
         "Editor-Version",

--- a/crates/ai/src/oauth/mod.rs
+++ b/crates/ai/src/oauth/mod.rs
@@ -439,6 +439,18 @@ fn form_encode(value: &str) -> String {
     encoded
 }
 
+/// Returns `response` unchanged when its status is a success, otherwise an
+/// [`Error::ApiStatus`] capturing the status code and response body. Shared by
+/// every OAuth HTTP call in this module so the error mapping stays consistent.
+async fn error_for_status(response: reqwest::Response) -> Result<reqwest::Response> {
+    if response.status().is_success() {
+        return Ok(response);
+    }
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    Err(Error::ApiStatus { status, body })
+}
+
 async fn abortable_sleep(
     duration: Duration,
     cancellation_token: Option<&CancellationToken>,


### PR DESCRIPTION
Follow-up to #82. The per-concern split left the same request/error boilerplate copied across the provider modules; this pulls it into single-source-of-truth helpers (pure refactor, no behavior change).

- **`error_for_status`** (`mod.rs`) — the `!is_success → ApiStatus { status, body }` mapping was copied **5×** across both providers; now one shared fn.
- **`github_oauth_form_post`** (`github_copilot.rs`) — the `Accept`/`User-Agent`/`Content-Type` form POST shared by the device-code, token-poll, and refresh-grant calls (**3 copies** → 1).
- **`post_anthropic_token_request`** (`anthropic.rs`) — the JSON token POST shared by the authorization-code and refresh-token exchanges.
- **`GITHUB_COPILOT_USER_AGENT`** const replacing **4** copies of the `"GitHubCopilotChat/0.35.0"` literal (the one remaining literal is a test assertion on the emitted header).

`cargo test -p ai` → **382 passed**; `cargo clippy -p ai` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)