### PR TITLE
ci: run clippy in workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,9 @@ jobs:
       - name: Check code formatting
         run: cargo fmt --all -- --check
 
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
       - name: Build
         run: cargo build --all --locked --verbose
 

--- a/examples/simple-coding-agent/src/main.rs
+++ b/examples/simple-coding-agent/src/main.rs
@@ -38,19 +38,19 @@ async fn main() -> Result<()> {
                         .unwrap_or("assistant stream failed")
                 );
             }
-            AgentEvent::MessageEnd { message } => {
-                if let Message::Assistant(message) = message {
-                    if let Some(error) = &message.error_message {
-                        eprintln!(
-                            "\nerror from {} ({}, {}): {error}",
-                            message.model, message.provider, message.api
-                        );
-                    } else if assistant_visible_content(&message).trim().is_empty() {
-                        eprintln!(
-                            "\nwarning: empty response from {} ({}, {})",
-                            message.model, message.provider, message.api
-                        );
-                    }
+            AgentEvent::MessageEnd {
+                message: Message::Assistant(message),
+            } => {
+                if let Some(error) = &message.error_message {
+                    eprintln!(
+                        "\nerror from {} ({}, {}): {error}",
+                        message.model, message.provider, message.api
+                    );
+                } else if assistant_visible_content(&message).trim().is_empty() {
+                    eprintln!(
+                        "\nwarning: empty response from {} ({}, {})",
+                        message.model, message.provider, message.api
+                    );
                 }
             }
             AgentEvent::ToolExecutionStart {
@@ -345,10 +345,10 @@ fn assistant_visible_content(message: &AssistantMessage) -> String {
     message
         .content
         .iter()
-        .filter_map(|content| match content {
-            AssistantContent::Text(text) => Some(text.text.as_str()),
-            AssistantContent::Thinking(thinking) => Some(thinking.thinking.as_str()),
-            AssistantContent::ToolCall(_) => Some("<tool_call>"),
+        .map(|content| match content {
+            AssistantContent::Text(text) => text.text.as_str(),
+            AssistantContent::Thinking(thinking) => thinking.thinking.as_str(),
+            AssistantContent::ToolCall(_) => "<tool_call>",
         })
         .collect()
 }


### PR DESCRIPTION
## Summary
- add the missing clippy step to the GitHub Actions workflow
- match the existing local `mise run clippy` command with warnings denied
- clean up existing simple-coding-agent clippy warnings so the new gate passes

## Verification
- `cargo fmt --all --check`
- `cargo clippy -p simple-coding-agent --all-targets -- -D warnings`
- `cargo test -p simple-coding-agent`