### PR TITLE
ci: use pinned rust toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.96.1
           override: true
           profile: minimal
           components: rustfmt, clippy


### PR DESCRIPTION
## Summary
- replace the moving `stable` toolchain in GitHub Actions with the repo-pinned Rust `1.96.1`
- keep CI aligned with `rust-toolchain.toml`

## Verification
- inspected the workflow diff against `rust-toolchain.toml`
- no Rust source changes