### PR TITLE
fix(example): limit bash tool execution

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,9 @@ jobs:
       - name: Check code formatting
         run: cargo fmt --all -- --check
 
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
       - name: Build
         run: cargo build --all --locked --verbose
 

--- a/examples/simple-coding-agent/src/main.rs
+++ b/examples/simple-coding-agent/src/main.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::io::Write;
+use std::time::Duration;
 
 use ai::{
     Agent, AgentError, AgentEvent, AgentOptions, AgentToolBuilder, AgentToolResult,
@@ -10,6 +11,9 @@ use ai::{
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
+
+const BASH_TOOL_TIMEOUT: Duration = Duration::from_secs(60);
+const BASH_TOOL_OUTPUT_LIMIT: usize = 16 * 1024;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -212,24 +216,50 @@ fn build_bash_tool() -> Result<DynAgentTool> {
                 .and_then(Value::as_str)
                 .ok_or_else(|| AgentError::Other("missing string argument: command".to_string()))?;
 
-            // For a production agent, add a timeout and cap output before
-            // returning stdout/stderr to the model.
-            let output = Command::new("bash")
-                .arg("-lc")
-                .arg(command)
-                .output()
-                .await
-                .map_err(|error| AgentError::Other(format!("failed to run bash: {error}")))?;
+            let output = tokio::time::timeout(
+                BASH_TOOL_TIMEOUT,
+                Command::new("bash")
+                    .kill_on_drop(true)
+                    .arg("-lc")
+                    .arg(command)
+                    .output(),
+            )
+            .await
+            .map_err(|_| AgentError::Other(format!("bash command timed out after {BASH_TOOL_TIMEOUT:?}")))?
+            .map_err(|error| AgentError::Other(format!("failed to run bash: {error}")))?;
 
-            let mut text = format!("exit status: {}\n", output.status);
-            text.push_str("\nstdout:\n");
-            text.push_str(&String::from_utf8_lossy(&output.stdout));
-            text.push_str("\n\nstderr:\n");
-            text.push_str(&String::from_utf8_lossy(&output.stderr));
+            let text = format_bash_output(
+                output.status.to_string(),
+                &output.stdout,
+                &output.stderr,
+                BASH_TOOL_OUTPUT_LIMIT,
+            );
 
             Ok(AgentToolResult::text(text))
         })
         .build()
+}
+
+fn format_bash_output(
+    status: impl std::fmt::Display,
+    stdout: &[u8],
+    stderr: &[u8],
+    limit: usize,
+) -> String {
+    let mut text = format!("exit status: {status}\n");
+    text.push_str("\nstdout:\n");
+    append_limited_utf8(&mut text, stdout, limit);
+    text.push_str("\n\nstderr:\n");
+    append_limited_utf8(&mut text, stderr, limit);
+    text
+}
+
+fn append_limited_utf8(text: &mut String, bytes: &[u8], limit: usize) {
+    let shown = bytes.len().min(limit);
+    text.push_str(&String::from_utf8_lossy(&bytes[..shown]));
+    if bytes.len() > shown {
+        text.push_str(&format!("\n[truncated {} bytes]", bytes.len() - shown));
+    }
 }
 
 #[derive(Clone)]
@@ -355,7 +385,7 @@ fn assistant_visible_content(message: &AssistantMessage) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{looks_like_github_token, openai_setup_error};
+    use super::{format_bash_output, looks_like_github_token, openai_setup_error};
 
     #[test]
     fn openai_setup_accepts_local_base_url_without_key() {
@@ -383,5 +413,24 @@ mod tests {
     #[test]
     fn openai_setup_accepts_openai_shaped_key() {
         assert_eq!(openai_setup_error(None, Some("sk-test")), None);
+    }
+
+    #[test]
+    fn bash_output_is_truncated_per_stream() {
+        let text = format_bash_output("exit 0", b"abcdef", b"12345", 3);
+
+        assert!(text.contains("stdout:\nabc\n[truncated 3 bytes]"));
+        assert!(text.contains("stderr:\n123\n[truncated 2 bytes]"));
+        assert!(!text.contains("def"));
+        assert!(!text.contains("45"));
+    }
+
+    #[test]
+    fn bash_output_keeps_short_streams_intact() {
+        let text = format_bash_output("exit 0", b"ok", b"", 16);
+
+        assert!(text.contains("exit status: exit 0"));
+        assert!(text.contains("stdout:\nok"));
+        assert!(text.ends_with("stderr:\n"));
     }
 }

--- a/examples/simple-coding-agent/src/main.rs
+++ b/examples/simple-coding-agent/src/main.rs
@@ -38,19 +38,19 @@ async fn main() -> Result<()> {
                         .unwrap_or("assistant stream failed")
                 );
             }
-            AgentEvent::MessageEnd { message } => {
-                if let Message::Assistant(message) = message {
-                    if let Some(error) = &message.error_message {
-                        eprintln!(
-                            "\nerror from {} ({}, {}): {error}",
-                            message.model, message.provider, message.api
-                        );
-                    } else if assistant_visible_content(&message).trim().is_empty() {
-                        eprintln!(
-                            "\nwarning: empty response from {} ({}, {})",
-                            message.model, message.provider, message.api
-                        );
-                    }
+            AgentEvent::MessageEnd {
+                message: Message::Assistant(message),
+            } => {
+                if let Some(error) = &message.error_message {
+                    eprintln!(
+                        "\nerror from {} ({}, {}): {error}",
+                        message.model, message.provider, message.api
+                    );
+                } else if assistant_visible_content(&message).trim().is_empty() {
+                    eprintln!(
+                        "\nwarning: empty response from {} ({}, {})",
+                        message.model, message.provider, message.api
+                    );
                 }
             }
             AgentEvent::ToolExecutionStart {
@@ -345,10 +345,10 @@ fn assistant_visible_content(message: &AssistantMessage) -> String {
     message
         .content
         .iter()
-        .filter_map(|content| match content {
-            AssistantContent::Text(text) => Some(text.text.as_str()),
-            AssistantContent::Thinking(thinking) => Some(thinking.thinking.as_str()),
-            AssistantContent::ToolCall(_) => Some("<tool_call>"),
+        .map(|content| match content {
+            AssistantContent::Text(text) => text.text.as_str(),
+            AssistantContent::Thinking(thinking) => thinking.thinking.as_str(),
+            AssistantContent::ToolCall(_) => "<tool_call>",
         })
         .collect()
 }


### PR DESCRIPTION
## Summary
- add a 60-second timeout to the simple coding agent bash tool
- kill the child process if the timeout future is dropped
- cap stdout and stderr returned to the model, with truncation markers
- add focused tests for bounded output formatting
- includes the clippy cleanup from `ci: run clippy in workflow` because GitHub cannot stack this fork PR on that fork branch as the upstream base

## Verification
- `cargo fmt --all --check`
- `cargo clippy -p simple-coding-agent --all-targets -- -D warnings`
- `cargo test -p simple-coding-agent`