### PR TITLE
docs: document PR conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,10 @@ provider is intentionally in scope.
 - Use semantic/conventional commit messages, such as `feat: add provider`,
   `fix: handle stream errors`, `docs: update README`, or
   `chore: update lockfile`.
+- Use the same semantic/conventional style for PR titles, such as
+  `feat: add provider`, `fix(example): limit bash tool execution`, or
+  `ci: run clippy in workflow`. PR bodies should include concise `Summary` and
+  `Verification` sections.
 - Keep public behavior aligned with the existing Rust API shape before adding
   new abstractions.
 - Add or update tests for provider payload changes, stream event ordering,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+## Pull Requests
+
+Use Conventional Commit-style PR titles, matching the convention used for
+commits. Examples:
+
+- `feat: add provider`
+- `fix(example): limit bash tool execution`
+- `ci: run clippy in workflow`
+- `docs: update README`
+
+PR bodies should include:
+
+- `Summary`: the behavior, docs, or workflow change in concise bullets.
+- `Verification`: commands run, checks inspected, or why a command was not run.


### PR DESCRIPTION
## Summary
- document Conventional Commit-style PR titles in `AGENTS.md`
- add `CONTRIBUTING.md` with PR title and body expectations

## Verification
- inspected docs diff; no code changes