### PR TITLE
feat: add max thinking level

### DIFF
--- a/crates/ai/src/models.rs
+++ b/crates/ai/src/models.rs
@@ -1,12 +1,13 @@
 use crate::types::{Model, ModelThinkingLevel, Usage, UsageCost};
 
-const EXTENDED_THINKING_LEVELS: [ModelThinkingLevel; 6] = [
+const EXTENDED_THINKING_LEVELS: [ModelThinkingLevel; 7] = [
     ModelThinkingLevel::Off,
     ModelThinkingLevel::Minimal,
     ModelThinkingLevel::Low,
     ModelThinkingLevel::Medium,
     ModelThinkingLevel::High,
     ModelThinkingLevel::Xhigh,
+    ModelThinkingLevel::Max,
 ];
 pub fn calculate_cost(model: &Model, usage: &mut Usage) -> UsageCost {
     usage.cost.input = (model.cost.input / 1_000_000.0) * usage.input as f64;
@@ -30,7 +31,7 @@ pub fn get_supported_thinking_levels(model: &Model) -> Vec<ModelThinkingLevel> {
             if matches!(mapped, Some(None)) {
                 return false;
             }
-            if *level == ModelThinkingLevel::Xhigh {
+            if *level == ModelThinkingLevel::Xhigh || *level == ModelThinkingLevel::Max {
                 return mapped.is_some();
             }
             true
@@ -119,6 +120,44 @@ mod tests {
                 ModelThinkingLevel::High,
                 ModelThinkingLevel::Xhigh,
             ]
+        );
+    }
+
+    #[test]
+    fn max_thinking_level_is_opt_in() {
+        let ordinary = Model {
+            reasoning: true,
+            ..Model::default()
+        };
+
+        assert_eq!(
+            clamp_thinking_level(&ordinary, ModelThinkingLevel::Max),
+            ModelThinkingLevel::High
+        );
+
+        let mut max_model = ordinary;
+        max_model
+            .thinking_level_map
+            .insert("xhigh".to_string(), Some("xhigh".to_string()));
+        max_model
+            .thinking_level_map
+            .insert("max".to_string(), Some("max".to_string()));
+
+        assert_eq!(
+            get_supported_thinking_levels(&max_model),
+            vec![
+                ModelThinkingLevel::Off,
+                ModelThinkingLevel::Minimal,
+                ModelThinkingLevel::Low,
+                ModelThinkingLevel::Medium,
+                ModelThinkingLevel::High,
+                ModelThinkingLevel::Xhigh,
+                ModelThinkingLevel::Max,
+            ]
+        );
+        assert_eq!(
+            clamp_thinking_level(&max_model, ModelThinkingLevel::Max),
+            ModelThinkingLevel::Max
         );
     }
 

--- a/crates/ai/src/providers/openai_responses.rs
+++ b/crates/ai/src/providers/openai_responses.rs
@@ -1471,6 +1471,33 @@ mod tests {
     }
 
     #[test]
+    fn builds_responses_payload_with_max_reasoning() {
+        let mut model = model();
+        model
+            .thinking_level_map
+            .insert("max".to_string(), Some("max".to_string()));
+        let context = Context {
+            messages: vec![Message::user_text("hi")],
+            ..Default::default()
+        };
+        let options = OpenAIResponsesOptions {
+            reasoning_effort: Some(ModelThinkingLevel::Max),
+            ..Default::default()
+        };
+
+        let payload = build_responses_payload(
+            &model,
+            &context,
+            &options,
+            &get_compat(&model),
+            CacheRetention::Short,
+        );
+
+        assert_eq!(payload["reasoning"]["effort"], "max");
+        assert_eq!(payload["include"][0], "reasoning.encrypted_content");
+    }
+
+    #[test]
     fn responses_payload_treats_off_reasoning_effort_as_unspecified() {
         let model = model();
         let context = Context {

--- a/crates/ai/src/providers/simple_options.rs
+++ b/crates/ai/src/providers/simple_options.rs
@@ -30,9 +30,9 @@ pub fn adjust_max_tokens_for_thinking(
         Some(ModelThinkingLevel::Minimal) => budgets.and_then(|b| b.minimal).unwrap_or(1_024),
         Some(ModelThinkingLevel::Low) => budgets.and_then(|b| b.low).unwrap_or(2_048),
         Some(ModelThinkingLevel::Medium) => budgets.and_then(|b| b.medium).unwrap_or(8_192),
-        Some(ModelThinkingLevel::High) | Some(ModelThinkingLevel::Xhigh) => {
-            budgets.and_then(|b| b.high).unwrap_or(16_384)
-        }
+        Some(ModelThinkingLevel::High)
+        | Some(ModelThinkingLevel::Xhigh)
+        | Some(ModelThinkingLevel::Max) => budgets.and_then(|b| b.high).unwrap_or(16_384),
         _ => 1_024,
     };
 

--- a/crates/ai/src/types.rs
+++ b/crates/ai/src/types.rs
@@ -50,6 +50,7 @@ pub enum ThinkingLevel {
     Medium,
     High,
     Xhigh,
+    Max,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -61,6 +62,7 @@ pub enum ModelThinkingLevel {
     Medium,
     High,
     Xhigh,
+    Max,
 }
 
 impl ModelThinkingLevel {
@@ -72,6 +74,7 @@ impl ModelThinkingLevel {
             Self::Medium => "medium",
             Self::High => "high",
             Self::Xhigh => "xhigh",
+            Self::Max => "max",
         }
     }
 
@@ -83,6 +86,7 @@ impl ModelThinkingLevel {
             "medium" => Some(Self::Medium),
             "high" => Some(Self::High),
             "xhigh" => Some(Self::Xhigh),
+            "max" => Some(Self::Max),
             _ => None,
         }
     }
@@ -96,6 +100,7 @@ impl From<ThinkingLevel> for ModelThinkingLevel {
             ThinkingLevel::Medium => Self::Medium,
             ThinkingLevel::High => Self::High,
             ThinkingLevel::Xhigh => Self::Xhigh,
+            ThinkingLevel::Max => Self::Max,
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `ModelThinkingLevel::Max` / `ThinkingLevel::Max`
- expose `max` only when a model opts in through `thinking_level_map`
- send `reasoning.effort = "max"` through OpenAI Responses when requested

## Verification
- `cargo fmt --all --check`
- `cargo check --workspace --all-targets`
- `cargo test -p ai`
