### PR TITLE
feat: add max thinking and compatible formats

### DIFF
--- a/crates/ai/README.md
+++ b/crates/ai/README.md
@@ -507,6 +507,10 @@ requests use `ImagesStopReason::Aborted`.
 
 Many models support thinking or reasoning content. Check `model.reasoning` and
 use `get_supported_thinking_levels` to inspect supported levels.
+`ModelThinkingLevel::Xhigh` and `ModelThinkingLevel::Max` are model-specific,
+opt-in levels: a model exposes them only when its `thinking_level_map` has a
+non-null `"xhigh"` or `"max"` entry. An unsupported request clamps to the
+nearest supported level.
 
 ### Unified Interface (streamSimple/completeSimple)
 
@@ -716,6 +720,61 @@ behavior from provider names or base URLs.
 Set model-builder compat metadata when the target OpenAI-compatible endpoint
 needs payload differences such as non-standard reasoning, cache-control,
 max-token, or tool-result behavior.
+
+For a server that controls thinking through Jinja chat-template arguments, use
+the generic `ChatTemplate` format. Static strings, JSON numbers, booleans, and
+null values pass through unchanged. `thinking_enabled()` resolves to a boolean;
+`thinking_effort(...)` resolves through the model's `thinking_level_map`.
+
+```rust
+use ai::{
+    ChatTemplateKwargValue, ModelCompat, ModelThinkingLevel,
+    OpenAICompletionsCompat, OpenAIThinkingFormat,
+};
+
+let compat = ModelCompat {
+    openai_completions: OpenAICompletionsCompat {
+        supports_reasoning_effort: Some(false),
+        thinking_format: Some(OpenAIThinkingFormat::ChatTemplate),
+        chat_template_kwargs: [
+            (
+                "enable_thinking".to_string(),
+                ChatTemplateKwargValue::thinking_enabled(),
+            ),
+            (
+                "reasoning_effort".to_string(),
+                ChatTemplateKwargValue::thinking_effort(true),
+            ),
+            ("preserve_thinking".to_string(), true.into()),
+        ]
+        .into_iter()
+        .collect(),
+        ..Default::default()
+    },
+    ..Default::default()
+};
+let mut model = provider
+    .model("local-reasoning-model")
+    .reasoning(true)
+    .compat(compat)
+    .build()?;
+model
+    .thinking_level_map
+    .insert("max".to_string(), Some("maximum".to_string()));
+let requested = ModelThinkingLevel::Max;
+```
+
+Here `omit_when_off = true` omits `reasoning_effort` when thinking is off. If it
+is false, an explicit `thinking_level_map["off"]` string is used. A mapped
+null value omits the variable.
+
+Ant Ling-compatible endpoints use a nested `reasoning: { effort }` object, but
+only for explicitly mapped levels. Opt in without provider-name or base-URL
+detection: set `thinking_format` to `AntLing`, set
+`supports_reasoning_effort` to false, and add the supported strings to the
+model's `thinking_level_map`. These endpoints commonly also set
+`supports_store` and `supports_developer_role` to false, `max_tokens_field` to
+`MaxTokens`, and `supports_long_cache_retention` to false.
 
 ### Thread Safety
 

--- a/crates/ai/src/models.rs
+++ b/crates/ai/src/models.rs
@@ -1,12 +1,13 @@
 use crate::types::{Model, ModelThinkingLevel, Usage, UsageCost};
 
-const EXTENDED_THINKING_LEVELS: [ModelThinkingLevel; 6] = [
+const EXTENDED_THINKING_LEVELS: [ModelThinkingLevel; 7] = [
     ModelThinkingLevel::Off,
     ModelThinkingLevel::Minimal,
     ModelThinkingLevel::Low,
     ModelThinkingLevel::Medium,
     ModelThinkingLevel::High,
     ModelThinkingLevel::Xhigh,
+    ModelThinkingLevel::Max,
 ];
 pub fn calculate_cost(model: &Model, usage: &mut Usage) -> UsageCost {
     usage.cost.input = (model.cost.input / 1_000_000.0) * usage.input as f64;
@@ -30,7 +31,7 @@ pub fn get_supported_thinking_levels(model: &Model) -> Vec<ModelThinkingLevel> {
             if matches!(mapped, Some(None)) {
                 return false;
             }
-            if *level == ModelThinkingLevel::Xhigh {
+            if matches!(level, ModelThinkingLevel::Xhigh | ModelThinkingLevel::Max) {
                 return mapped.is_some();
             }
             true
@@ -98,7 +99,7 @@ mod tests {
     }
 
     #[test]
-    fn supported_thinking_levels_match_xhigh_metadata() {
+    fn supported_thinking_levels_match_extended_metadata() {
         let mut gpt55_pro = Model {
             reasoning: true,
             ..Model::default()
@@ -111,6 +112,9 @@ mod tests {
         gpt55_pro
             .thinking_level_map
             .insert("xhigh".to_string(), Some("high".to_string()));
+        gpt55_pro
+            .thinking_level_map
+            .insert("max".to_string(), Some("max".to_string()));
 
         assert_eq!(
             get_supported_thinking_levels(&gpt55_pro),
@@ -118,7 +122,59 @@ mod tests {
                 ModelThinkingLevel::Medium,
                 ModelThinkingLevel::High,
                 ModelThinkingLevel::Xhigh,
+                ModelThinkingLevel::Max,
             ]
+        );
+    }
+
+    #[test]
+    fn max_is_opt_in_for_ordinary_reasoning_models() {
+        let model = Model {
+            reasoning: true,
+            ..Model::default()
+        };
+
+        assert_eq!(
+            get_supported_thinking_levels(&model),
+            vec![
+                ModelThinkingLevel::Off,
+                ModelThinkingLevel::Minimal,
+                ModelThinkingLevel::Low,
+                ModelThinkingLevel::Medium,
+                ModelThinkingLevel::High,
+            ]
+        );
+        assert_eq!(
+            clamp_thinking_level(&model, ModelThinkingLevel::Max),
+            ModelThinkingLevel::High
+        );
+    }
+
+    #[test]
+    fn unsupported_xhigh_clamps_up_to_supported_max() {
+        let mut model = Model {
+            reasoning: true,
+            ..Model::default()
+        };
+        model.thinking_level_map.insert("xhigh".to_string(), None);
+        model
+            .thinking_level_map
+            .insert("max".to_string(), Some("max".to_string()));
+
+        assert_eq!(
+            get_supported_thinking_levels(&model),
+            vec![
+                ModelThinkingLevel::Off,
+                ModelThinkingLevel::Minimal,
+                ModelThinkingLevel::Low,
+                ModelThinkingLevel::Medium,
+                ModelThinkingLevel::High,
+                ModelThinkingLevel::Max,
+            ]
+        );
+        assert_eq!(
+            clamp_thinking_level(&model, ModelThinkingLevel::Xhigh),
+            ModelThinkingLevel::Max
         );
     }
 

--- a/crates/ai/src/providers/anthropic.rs
+++ b/crates/ai/src/providers/anthropic.rs
@@ -1279,6 +1279,7 @@ fn map_thinking_level_to_effort(model: &Model, level: ModelThinkingLevel) -> Ant
         ModelThinkingLevel::Minimal | ModelThinkingLevel::Low => AnthropicEffort::Low,
         ModelThinkingLevel::Medium => AnthropicEffort::Medium,
         ModelThinkingLevel::High => AnthropicEffort::High,
+        ModelThinkingLevel::Xhigh | ModelThinkingLevel::Max => AnthropicEffort::High,
         _ => AnthropicEffort::High,
     }
 }
@@ -2004,6 +2005,49 @@ mod tests {
             json!({ "type": "adaptive", "display": "summarized" })
         );
         assert_eq!(payload["output_config"], json!({ "effort": "xhigh" }));
+    }
+
+    #[test]
+    fn maps_max_reasoning_to_effort_max_for_adaptive_models() {
+        let mut model = anthropic_model("vendor--claude-opus-latest");
+        model.provider = "vendor-proxy".to_string();
+        model.compat.anthropic_messages.force_adaptive_thinking = Some(true);
+        model
+            .thinking_level_map
+            .insert("max".to_string(), Some("max".to_string()));
+        let payload = build_anthropic_payload(
+            &model,
+            &Context {
+                messages: vec![crate::types::Message::user_text("hello")],
+                ..Default::default()
+            },
+            &AnthropicOptions {
+                thinking_enabled: Some(true),
+                effort: Some(map_thinking_level_to_effort(
+                    &model,
+                    ModelThinkingLevel::Max,
+                )),
+                ..Default::default()
+            },
+            false,
+            None,
+        );
+
+        assert_eq!(payload["output_config"], json!({ "effort": "max" }));
+    }
+
+    #[test]
+    fn unmapped_extended_reasoning_levels_fall_back_to_high() {
+        let model = anthropic_model("vendor--claude-opus-latest");
+
+        assert_eq!(
+            map_thinking_level_to_effort(&model, ModelThinkingLevel::Xhigh),
+            AnthropicEffort::High
+        );
+        assert_eq!(
+            map_thinking_level_to_effort(&model, ModelThinkingLevel::Max),
+            AnthropicEffort::High
+        );
     }
 
     #[test]

--- a/crates/ai/src/providers/openai_completions.rs
+++ b/crates/ai/src/providers/openai_completions.rs
@@ -14,9 +14,10 @@ use crate::providers::simple_options::build_base_options;
 use crate::providers::transform_messages::transform_messages;
 use crate::types::{
     AssistantContent, AssistantMessage, AssistantMessageEvent, CacheControlFormat, CacheRetention,
-    Context, ImageContent, MaxTokensField, Model, ModelInput, ModelThinkingLevel,
-    OpenAIThinkingFormat, SimpleStreamOptions, StopReason, StreamOptions, TextContent,
-    ThinkingContent, Tool, ToolCall, ToolResultContent, Usage, UserContent, UserMessageContent,
+    ChatTemplateKwargValue, ChatTemplateVariable, Context, ImageContent, MaxTokensField, Model,
+    ModelInput, ModelThinkingLevel, OpenAIThinkingFormat, SimpleStreamOptions, StopReason,
+    StreamOptions, TextContent, ThinkingContent, Tool, ToolCall, ToolResultContent, Usage,
+    UserContent, UserMessageContent,
 };
 use crate::utils::http::{request_timeout, send_with_retries};
 use crate::utils::json::parse_streaming_json;
@@ -42,6 +43,7 @@ struct ResolvedOpenAICompletionsCompat {
     requires_thinking_as_text: bool,
     requires_reasoning_content_on_assistant_messages: bool,
     thinking_format: OpenAIThinkingFormat,
+    chat_template_kwargs: HashMap<String, ChatTemplateKwargValue>,
     open_router_routing: Option<Value>,
     vercel_gateway_routing: Option<Value>,
     zai_tool_stream: bool,
@@ -689,14 +691,15 @@ fn apply_reasoning_options(
     let effort = options
         .reasoning_effort
         .filter(|effort| *effort != ModelThinkingLevel::Off);
+    let configured_effort = effort.and_then(|effort| {
+        model
+            .thinking_level_map
+            .get(effort.as_str())
+            .cloned()
+            .flatten()
+    });
     let mapped_effort = effort
-        .and_then(|effort| {
-            model
-                .thinking_level_map
-                .get(effort.as_str())
-                .cloned()
-                .flatten()
-        })
+        .and(configured_effort.clone())
         .or_else(|| effort.map(|effort| effort.as_str().to_string()));
 
     match compat.thinking_format {
@@ -711,6 +714,11 @@ fn apply_reasoning_options(
                 "chat_template_kwargs".to_string(),
                 json!({ "enable_thinking": mapped_effort.is_some(), "preserve_thinking": true }),
             );
+        }
+        OpenAIThinkingFormat::ChatTemplate => {
+            if let Some(kwargs) = build_chat_template_kwargs(model, effort, compat) {
+                object.insert("chat_template_kwargs".to_string(), Value::Object(kwargs));
+            }
         }
         OpenAIThinkingFormat::Deepseek => {
             object.insert(
@@ -756,6 +764,11 @@ fn apply_reasoning_options(
                 );
             }
         }
+        OpenAIThinkingFormat::AntLing => {
+            if let Some(effort) = configured_effort {
+                object.insert("reasoning".to_string(), json!({ "effort": effort }));
+            }
+        }
         OpenAIThinkingFormat::Openai => {
             if let Some(effort) = mapped_effort.filter(|_| compat.supports_reasoning_effort) {
                 object.insert("reasoning_effort".to_string(), json!(effort));
@@ -763,6 +776,54 @@ fn apply_reasoning_options(
                 && let Some(Some(off)) = model.thinking_level_map.get("off")
             {
                 object.insert("reasoning_effort".to_string(), json!(off));
+            }
+        }
+    }
+}
+
+fn build_chat_template_kwargs(
+    model: &Model,
+    effort: Option<ModelThinkingLevel>,
+    compat: &ResolvedOpenAICompletionsCompat,
+) -> Option<serde_json::Map<String, Value>> {
+    let kwargs = compat
+        .chat_template_kwargs
+        .iter()
+        .filter_map(|(key, value)| {
+            resolve_chat_template_kwarg_value(model, effort, value)
+                .map(|value| (key.clone(), value))
+        })
+        .collect::<serde_json::Map<_, _>>();
+    (!kwargs.is_empty()).then_some(kwargs)
+}
+
+fn resolve_chat_template_kwarg_value(
+    model: &Model,
+    effort: Option<ModelThinkingLevel>,
+    value: &ChatTemplateKwargValue,
+) -> Option<Value> {
+    match value {
+        ChatTemplateKwargValue::String(value) => Some(json!(value)),
+        ChatTemplateKwargValue::Number(value) => Some(Value::Number(value.clone())),
+        ChatTemplateKwargValue::Boolean(value) => Some(json!(value)),
+        ChatTemplateKwargValue::Null(()) => Some(Value::Null),
+        ChatTemplateKwargValue::Variable(variable) => {
+            if effort.is_none() && variable.omit_when_off {
+                return None;
+            }
+            match variable.variable {
+                ChatTemplateVariable::ThinkingEnabled => Some(json!(effort.is_some())),
+                ChatTemplateVariable::ThinkingEffort => {
+                    let mapped = match effort {
+                        Some(effort) => model.thinking_level_map.get(effort.as_str()),
+                        None => model.thinking_level_map.get("off"),
+                    };
+                    match mapped {
+                        Some(Some(value)) => Some(json!(value)),
+                        Some(None) => None,
+                        None => effort.map(|effort| json!(effort.as_str())),
+                    }
+                }
             }
         }
     }
@@ -1095,6 +1156,7 @@ fn detect_compat(_model: &Model) -> ResolvedOpenAICompletionsCompat {
         requires_thinking_as_text: false,
         requires_reasoning_content_on_assistant_messages: false,
         thinking_format: OpenAIThinkingFormat::Openai,
+        chat_template_kwargs: HashMap::new(),
         open_router_routing: None,
         vercel_gateway_routing: None,
         zai_tool_stream: false,
@@ -1133,6 +1195,11 @@ fn get_compat(model: &Model) -> ResolvedOpenAICompletionsCompat {
             .requires_reasoning_content_on_assistant_messages
             .unwrap_or(detected.requires_reasoning_content_on_assistant_messages),
         thinking_format: compat.thinking_format.unwrap_or(detected.thinking_format),
+        chat_template_kwargs: if compat.chat_template_kwargs.is_empty() {
+            detected.chat_template_kwargs
+        } else {
+            compat.chat_template_kwargs.clone()
+        },
         open_router_routing: compat
             .open_router_routing
             .clone()
@@ -3970,6 +4037,278 @@ mod tests {
         );
 
         assert_eq!(payload["reasoning_effort"], json!("default"));
+    }
+
+    #[test]
+    fn max_reasoning_effort_uses_model_mapping() {
+        let mut model = model();
+        model.provider = "custom-openai-compatible".to_string();
+        model
+            .thinking_level_map
+            .insert("max".to_string(), Some("maximum".to_string()));
+        let payload = build_chat_completions_payload(
+            &model,
+            &Context {
+                messages: vec![Message::user_text("Think as hard as possible.")],
+                ..Default::default()
+            },
+            &OpenAICompletionsOptions {
+                reasoning_effort: Some(ModelThinkingLevel::Max),
+                ..Default::default()
+            },
+            &get_compat(&model),
+            CacheRetention::Short,
+        );
+
+        assert_eq!(payload["reasoning_effort"], json!("maximum"));
+    }
+
+    #[test]
+    fn configurable_chat_template_boolean_thinking_kwargs() {
+        let mut model = model();
+        model.provider = "custom-openai-compatible".to_string();
+        model.compat.openai_completions.thinking_format = Some(OpenAIThinkingFormat::ChatTemplate);
+        model.compat.openai_completions.chat_template_kwargs.insert(
+            "thinking".to_string(),
+            ChatTemplateKwargValue::thinking_enabled(),
+        );
+        let compat = get_compat(&model);
+
+        let enabled = build_chat_completions_payload(
+            &model,
+            &Context::default(),
+            &OpenAICompletionsOptions {
+                reasoning_effort: Some(ModelThinkingLevel::High),
+                ..Default::default()
+            },
+            &compat,
+            CacheRetention::Short,
+        );
+        let disabled = build_chat_completions_payload(
+            &model,
+            &Context::default(),
+            &OpenAICompletionsOptions::default(),
+            &compat,
+            CacheRetention::Short,
+        );
+
+        assert_eq!(enabled["chat_template_kwargs"], json!({ "thinking": true }));
+        assert_eq!(
+            disabled["chat_template_kwargs"],
+            json!({ "thinking": false })
+        );
+        assert!(enabled.get("reasoning_effort").is_none());
+        assert!(enabled.get("thinking").is_none());
+        assert!(disabled.get("reasoning_effort").is_none());
+        assert!(disabled.get("thinking").is_none());
+    }
+
+    #[test]
+    fn qwen_chat_template_thinking_kwargs() {
+        let mut model = model();
+        model.provider = "custom-openai-compatible".to_string();
+        model.compat.openai_completions.thinking_format =
+            Some(OpenAIThinkingFormat::QwenChatTemplate);
+        model.compat.openai_completions.supports_reasoning_effort = Some(false);
+        let compat = get_compat(&model);
+
+        for (reasoning_effort, expected) in [(Some(ModelThinkingLevel::High), true), (None, false)]
+        {
+            let payload = build_chat_completions_payload(
+                &model,
+                &Context::default(),
+                &OpenAICompletionsOptions {
+                    reasoning_effort,
+                    ..Default::default()
+                },
+                &compat,
+                CacheRetention::Short,
+            );
+
+            assert_eq!(
+                payload["chat_template_kwargs"],
+                json!({ "enable_thinking": expected, "preserve_thinking": true })
+            );
+            assert!(payload.get("reasoning_effort").is_none());
+        }
+    }
+
+    #[test]
+    fn configurable_chat_template_effort_kwargs_and_static_values() {
+        let mut model = model();
+        model.provider = "custom-openai-compatible".to_string();
+        model
+            .thinking_level_map
+            .insert("xhigh".to_string(), Some("max".to_string()));
+        model.compat.openai_completions.thinking_format = Some(OpenAIThinkingFormat::ChatTemplate);
+        model.compat.openai_completions.chat_template_kwargs = [
+            ("preserve_thinking".to_string(), true.into()),
+            (
+                "reasoning_effort".to_string(),
+                ChatTemplateKwargValue::thinking_effort(true),
+            ),
+            ("seed".to_string(), 7_u32.into()),
+            ("label".to_string(), "local".into()),
+        ]
+        .into_iter()
+        .collect();
+        let compat = get_compat(&model);
+
+        let enabled = build_chat_completions_payload(
+            &model,
+            &Context::default(),
+            &OpenAICompletionsOptions {
+                reasoning_effort: Some(ModelThinkingLevel::Xhigh),
+                ..Default::default()
+            },
+            &compat,
+            CacheRetention::Short,
+        );
+        let disabled = build_chat_completions_payload(
+            &model,
+            &Context::default(),
+            &OpenAICompletionsOptions::default(),
+            &compat,
+            CacheRetention::Short,
+        );
+
+        assert_eq!(
+            enabled["chat_template_kwargs"],
+            json!({
+                "preserve_thinking": true,
+                "reasoning_effort": "max",
+                "seed": 7,
+                "label": "local"
+            })
+        );
+        assert_eq!(
+            disabled["chat_template_kwargs"],
+            json!({ "preserve_thinking": true, "seed": 7, "label": "local" })
+        );
+        assert!(enabled.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn chat_template_effort_uses_off_mapping_when_not_omitted() {
+        let mut model = model();
+        model.provider = "custom-openai-compatible".to_string();
+        model
+            .thinking_level_map
+            .insert("off".to_string(), Some("none".to_string()));
+        model.compat.openai_completions.thinking_format = Some(OpenAIThinkingFormat::ChatTemplate);
+        model.compat.openai_completions.chat_template_kwargs.insert(
+            "reasoning_effort".to_string(),
+            ChatTemplateKwargValue::thinking_effort(false),
+        );
+
+        let payload = build_chat_completions_payload(
+            &model,
+            &Context::default(),
+            &OpenAICompletionsOptions::default(),
+            &get_compat(&model),
+            CacheRetention::Short,
+        );
+
+        assert_eq!(
+            payload["chat_template_kwargs"],
+            json!({ "reasoning_effort": "none" })
+        );
+    }
+
+    #[test]
+    fn ant_ling_compatibility_metadata_shapes_the_full_payload() {
+        let mut model = model();
+        model.provider = "custom-ant-ling-compatible".to_string();
+        model.compat.openai_completions.supports_store = Some(false);
+        model.compat.openai_completions.supports_developer_role = Some(false);
+        model.compat.openai_completions.supports_reasoning_effort = Some(false);
+        model.compat.openai_completions.max_tokens_field = Some(MaxTokensField::MaxTokens);
+        model.compat.openai_completions.thinking_format = Some(OpenAIThinkingFormat::AntLing);
+        model
+            .compat
+            .openai_completions
+            .supports_long_cache_retention = Some(false);
+        model
+            .thinking_level_map
+            .insert("high".to_string(), Some("high".to_string()));
+
+        let payload = build_chat_completions_payload(
+            &model,
+            &Context {
+                system_prompt: Some("Follow instructions.".to_string()),
+                messages: vec![Message::user_text("Hi")],
+                ..Default::default()
+            },
+            &OpenAICompletionsOptions {
+                base: StreamOptions {
+                    max_tokens: Some(123),
+                    session_id: Some("ant-ling-session".to_string()),
+                    ..Default::default()
+                },
+                reasoning_effort: Some(ModelThinkingLevel::High),
+                ..Default::default()
+            },
+            &get_compat(&model),
+            CacheRetention::Long,
+        );
+
+        assert_eq!(payload["max_tokens"], json!(123));
+        assert!(payload.get("max_completion_tokens").is_none());
+        assert_eq!(payload["messages"][0]["role"], json!("system"));
+        assert_eq!(payload["reasoning"], json!({ "effort": "high" }));
+        assert!(payload.get("reasoning_effort").is_none());
+        assert!(payload.get("store").is_none());
+        assert!(payload.get("prompt_cache_key").is_none());
+        assert!(payload.get("prompt_cache_retention").is_none());
+    }
+
+    #[test]
+    fn ant_ling_only_sends_explicitly_mapped_efforts() {
+        let mut model = model();
+        model.provider = "custom-ant-ling-compatible".to_string();
+        model.compat.openai_completions.thinking_format = Some(OpenAIThinkingFormat::AntLing);
+        model
+            .thinking_level_map
+            .insert("high".to_string(), Some("high".to_string()));
+        let compat = get_compat(&model);
+
+        let mapped = build_chat_completions_payload(
+            &model,
+            &Context::default(),
+            &OpenAICompletionsOptions {
+                reasoning_effort: Some(ModelThinkingLevel::High),
+                ..Default::default()
+            },
+            &compat,
+            CacheRetention::Short,
+        );
+        let unmapped = build_chat_completions_payload(
+            &model,
+            &Context::default(),
+            &OpenAICompletionsOptions {
+                reasoning_effort: Some(ModelThinkingLevel::Medium),
+                ..Default::default()
+            },
+            &compat,
+            CacheRetention::Short,
+        );
+        let mut non_reasoning = model.clone();
+        non_reasoning.reasoning = false;
+        let disabled = build_chat_completions_payload(
+            &non_reasoning,
+            &Context::default(),
+            &OpenAICompletionsOptions {
+                reasoning_effort: Some(ModelThinkingLevel::High),
+                ..Default::default()
+            },
+            &get_compat(&non_reasoning),
+            CacheRetention::Short,
+        );
+
+        assert_eq!(mapped["reasoning"], json!({ "effort": "high" }));
+        assert!(mapped.get("reasoning_effort").is_none());
+        assert!(unmapped.get("reasoning").is_none());
+        assert!(disabled.get("reasoning").is_none());
     }
 
     #[test]

--- a/crates/ai/src/providers/openai_responses.rs
+++ b/crates/ai/src/providers/openai_responses.rs
@@ -1259,12 +1259,12 @@ fn openai_error_message(body: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use std::sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     };
 
     use super::*;
-    use crate::types::{Message, ModelCost, ResponseHook, ToolResultMessage};
+    use crate::types::{Message, ModelCost, PayloadHook, ResponseHook, ToolResultMessage};
     use futures::StreamExt;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
@@ -1468,6 +1468,69 @@ mod tests {
         assert_eq!(payload["input"][0]["role"], "developer");
         assert_eq!(payload["reasoning"]["effort"], "low");
         assert_eq!(payload["include"][0], "reasoning.encrypted_content");
+    }
+
+    #[tokio::test]
+    async fn stream_simple_sends_mapped_max_reasoning_to_responses_api() {
+        let body = sse_body(&[json!({
+            "type": "response.completed",
+            "response": {
+                "id": "resp_max",
+                "status": "completed",
+                "usage": {
+                    "input_tokens": 1,
+                    "output_tokens": 1,
+                    "total_tokens": 2,
+                    "input_tokens_details": { "cached_tokens": 0 }
+                }
+            }
+        })]);
+        let mut model = model();
+        model.provider = "custom-openai-compatible".to_string();
+        model.base_url = spawn_sse_server(body).await;
+        model
+            .thinking_level_map
+            .insert("max".to_string(), Some("max".to_string()));
+
+        let captured_payload = Arc::new(Mutex::new(None));
+        let hook_capture = Arc::clone(&captured_payload);
+        let on_payload: PayloadHook = Arc::new(move |payload, _model| {
+            let hook_capture = Arc::clone(&hook_capture);
+            Box::pin(async move {
+                *hook_capture.lock().unwrap() = Some(payload.clone());
+                Ok(Some(payload))
+            })
+        });
+
+        let stream = stream_simple_openai_responses(
+            model,
+            Context {
+                system_prompt: Some("You are a helpful assistant.".to_string()),
+                messages: vec![Message::user_text("Hello")],
+                ..Default::default()
+            },
+            SimpleStreamOptions {
+                stream: StreamOptions {
+                    api_key: Some("test-key".to_string()),
+                    cache_retention: Some(CacheRetention::None),
+                    on_payload: Some(on_payload),
+                    ..Default::default()
+                },
+                reasoning: Some(ModelThinkingLevel::Max),
+                ..Default::default()
+            },
+        )
+        .expect("stream");
+
+        let message = crate::stream::final_message_from_stream(stream)
+            .await
+            .expect("final message");
+        assert_eq!(message.stop_reason, StopReason::Stop);
+        let payload = captured_payload.lock().unwrap().take().expect("payload");
+        assert_eq!(
+            payload["reasoning"],
+            json!({ "effort": "max", "summary": "auto" })
+        );
     }
 
     #[test]

--- a/crates/ai/src/providers/simple_options.rs
+++ b/crates/ai/src/providers/simple_options.rs
@@ -30,9 +30,9 @@ pub fn adjust_max_tokens_for_thinking(
         Some(ModelThinkingLevel::Minimal) => budgets.and_then(|b| b.minimal).unwrap_or(1_024),
         Some(ModelThinkingLevel::Low) => budgets.and_then(|b| b.low).unwrap_or(2_048),
         Some(ModelThinkingLevel::Medium) => budgets.and_then(|b| b.medium).unwrap_or(8_192),
-        Some(ModelThinkingLevel::High) | Some(ModelThinkingLevel::Xhigh) => {
-            budgets.and_then(|b| b.high).unwrap_or(16_384)
-        }
+        Some(ModelThinkingLevel::High)
+        | Some(ModelThinkingLevel::Xhigh)
+        | Some(ModelThinkingLevel::Max) => budgets.and_then(|b| b.high).unwrap_or(16_384),
         _ => 1_024,
     };
 

--- a/crates/ai/src/types.rs
+++ b/crates/ai/src/types.rs
@@ -14,6 +14,10 @@ use crate::provider::LanguageModelApi;
 pub type Api = String;
 pub type ProviderId = String;
 
+fn is_false(value: &bool) -> bool {
+    !value
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum KnownApi {
@@ -50,6 +54,7 @@ pub enum ThinkingLevel {
     Medium,
     High,
     Xhigh,
+    Max,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -61,6 +66,7 @@ pub enum ModelThinkingLevel {
     Medium,
     High,
     Xhigh,
+    Max,
 }
 
 impl ModelThinkingLevel {
@@ -72,6 +78,7 @@ impl ModelThinkingLevel {
             Self::Medium => "medium",
             Self::High => "high",
             Self::Xhigh => "xhigh",
+            Self::Max => "max",
         }
     }
 
@@ -83,6 +90,7 @@ impl ModelThinkingLevel {
             "medium" => Some(Self::Medium),
             "high" => Some(Self::High),
             "xhigh" => Some(Self::Xhigh),
+            "max" => Some(Self::Max),
             _ => None,
         }
     }
@@ -96,6 +104,7 @@ impl From<ThinkingLevel> for ModelThinkingLevel {
             ThinkingLevel::Medium => Self::Medium,
             ThinkingLevel::High => Self::High,
             ThinkingLevel::Xhigh => Self::Xhigh,
+            ThinkingLevel::Max => Self::Max,
         }
     }
 }
@@ -1040,6 +1049,8 @@ pub struct OpenAICompletionsCompat {
     pub requires_reasoning_content_on_assistant_messages: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thinking_format: Option<OpenAIThinkingFormat>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub chat_template_kwargs: HashMap<String, ChatTemplateKwargValue>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub open_router_routing: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1073,7 +1084,88 @@ pub enum OpenAIThinkingFormat {
     Zai,
     Qwen,
     QwenChatTemplate,
+    ChatTemplate,
     StringThinking,
+    AntLing,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ChatTemplateKwargValue {
+    String(String),
+    Number(serde_json::Number),
+    Boolean(bool),
+    Null(()),
+    Variable(ChatTemplateKwargVariable),
+}
+
+impl ChatTemplateKwargValue {
+    pub fn from_f64(value: f64) -> Option<Self> {
+        serde_json::Number::from_f64(value).map(Self::Number)
+    }
+
+    pub fn thinking_enabled() -> Self {
+        Self::Variable(ChatTemplateKwargVariable {
+            variable: ChatTemplateVariable::ThinkingEnabled,
+            omit_when_off: false,
+        })
+    }
+
+    pub fn thinking_effort(omit_when_off: bool) -> Self {
+        Self::Variable(ChatTemplateKwargVariable {
+            variable: ChatTemplateVariable::ThinkingEffort,
+            omit_when_off,
+        })
+    }
+}
+
+impl From<String> for ChatTemplateKwargValue {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<&str> for ChatTemplateKwargValue {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_string())
+    }
+}
+
+impl From<bool> for ChatTemplateKwargValue {
+    fn from(value: bool) -> Self {
+        Self::Boolean(value)
+    }
+}
+
+macro_rules! impl_chat_template_kwarg_number {
+    ($($type:ty),+ $(,)?) => {
+        $(
+            impl From<$type> for ChatTemplateKwargValue {
+                fn from(value: $type) -> Self {
+                    Self::Number(value.into())
+                }
+            }
+        )+
+    };
+}
+
+impl_chat_template_kwarg_number!(i8, i16, i32, i64, u8, u16, u32, u64);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatTemplateKwargVariable {
+    #[serde(rename = "$var")]
+    pub variable: ChatTemplateVariable,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub omit_when_off: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ChatTemplateVariable {
+    #[serde(rename = "thinking.enabled")]
+    ThinkingEnabled,
+    #[serde(rename = "thinking.effort")]
+    ThinkingEffort,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1358,5 +1450,76 @@ mod tests {
                 "id": "gpt-5.5"
             })
         );
+    }
+
+    #[test]
+    fn max_thinking_level_round_trips() {
+        assert_eq!(
+            serde_json::to_value(ThinkingLevel::Max).unwrap(),
+            json!("max")
+        );
+        assert_eq!(
+            serde_json::from_value::<ThinkingLevel>(json!("max")).unwrap(),
+            ThinkingLevel::Max
+        );
+        assert_eq!(
+            serde_json::to_value(ModelThinkingLevel::Max).unwrap(),
+            json!("max")
+        );
+        assert_eq!(
+            serde_json::from_value::<ModelThinkingLevel>(json!("max")).unwrap(),
+            ModelThinkingLevel::Max
+        );
+        assert_eq!(
+            ModelThinkingLevel::parse("max"),
+            Some(ModelThinkingLevel::Max)
+        );
+    }
+
+    #[test]
+    fn chat_template_compat_round_trips() {
+        let compat = OpenAICompletionsCompat {
+            thinking_format: Some(OpenAIThinkingFormat::ChatTemplate),
+            chat_template_kwargs: [
+                (
+                    "enabled".to_string(),
+                    ChatTemplateKwargValue::thinking_enabled(),
+                ),
+                (
+                    "effort".to_string(),
+                    ChatTemplateKwargValue::thinking_effort(true),
+                ),
+                ("preserve".to_string(), true.into()),
+                (
+                    "temperature".to_string(),
+                    ChatTemplateKwargValue::from_f64(0.5).unwrap(),
+                ),
+                ("sentinel".to_string(), ChatTemplateKwargValue::Null(())),
+            ]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+        let value = serde_json::to_value(&compat).unwrap();
+        let restored: OpenAICompletionsCompat = serde_json::from_value(value.clone()).unwrap();
+
+        assert_eq!(value["thinkingFormat"], json!("chat-template"));
+        assert_eq!(
+            value["chatTemplateKwargs"]["enabled"],
+            json!({ "$var": "thinking.enabled" })
+        );
+        assert_eq!(
+            value["chatTemplateKwargs"]["effort"],
+            json!({ "$var": "thinking.effort", "omitWhenOff": true })
+        );
+        assert_eq!(value["chatTemplateKwargs"]["temperature"], json!(0.5));
+        assert_eq!(value["chatTemplateKwargs"]["sentinel"], Value::Null);
+        assert_eq!(restored, compat);
+    }
+
+    #[test]
+    fn chat_template_float_values_reject_non_finite_numbers() {
+        assert!(ChatTemplateKwargValue::from_f64(f64::NAN).is_none());
+        assert!(ChatTemplateKwargValue::from_f64(f64::INFINITY).is_none());
     }
 }


### PR DESCRIPTION
## Summary

- add opt-in `max` thinking support with pi-compatible ordering, clamping, serialization, and provider mapping
- add generic chat-template thinking kwargs and explicit Ant Ling-compatible request shaping
- port the corresponding pi payload and edge-case tests, and document custom endpoint configuration
- close fer ticket `ai.-yg0s`

## Verification

- `mise run all`
- direct comparison against current pi max-thinking, chat-template, Ant Ling, OpenAI Responses, and Anthropic semantics
- 397 `ai` crate tests and 5 example tests passed