### PR TITLE
fix: align provider retry delays with pi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "base64",
  "dyn-clone",
  "futures",
+ "httpdate",
  "parking_lot",
  "regex",
  "reqwest",
@@ -383,6 +384,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ async-trait = "0.1.85"
 base64 = "0.22.1"
 dyn-clone = "1.0.17"
 futures = "0.3.31"
+httpdate = "1.0.3"
 parking_lot = "0.12.5"
 reqwest = { version = "0.13.0", features = ["json", "rustls", "stream"], default-features = false }
 regex = "1.11.1"

--- a/crates/ai/Cargo.toml
+++ b/crates/ai/Cargo.toml
@@ -14,6 +14,7 @@ async-stream.workspace = true
 base64.workspace = true
 dyn-clone.workspace = true
 futures.workspace = true
+httpdate.workspace = true
 parking_lot.workspace = true
 reqwest.workspace = true
 regex.workspace = true

--- a/crates/ai/src/providers/openai_completions.rs
+++ b/crates/ai/src/providers/openai_completions.rs
@@ -2605,6 +2605,33 @@ mod tests {
         format!("http://{addr}")
     }
 
+    async fn spawn_retry_delay_server(
+        attempts: Arc<AtomicUsize>,
+        retry_after: &str,
+        body: &str,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let retry_after = retry_after.to_string();
+        let body = body.to_string();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                attempts.fetch_add(1, Ordering::SeqCst);
+                let mut buffer = vec![0u8; 4096];
+                let _ = socket.read(&mut buffer).await;
+                let response = format!(
+                    "HTTP/1.1 429 Too Many Requests\r\nretry-after: {retry_after}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+            }
+        });
+        format!("http://{addr}")
+    }
+
     #[tokio::test]
     async fn surfaces_routed_chunk_model_as_response_model() {
         let mut routed_model = model();
@@ -2945,6 +2972,50 @@ mod tests {
                 text: "ok".to_string(),
                 text_signature: None,
             })]
+        );
+    }
+
+    #[tokio::test]
+    async fn chat_provider_fails_immediately_for_retry_delay_above_limit() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let mut chat_model = model();
+        chat_model.reasoning = false;
+        chat_model.base_url =
+            spawn_retry_delay_server(Arc::clone(&attempts), "277403", "rate limited").await;
+
+        let stream = stream_openai_completions(
+            chat_model,
+            Context {
+                messages: vec![Message::user_text("hello")],
+                ..Default::default()
+            },
+            OpenAICompletionsOptions {
+                base: StreamOptions {
+                    api_key: Some("test-key".to_string()),
+                    cache_retention: Some(CacheRetention::None),
+                    max_retries: Some(2),
+                    max_retry_delay_ms: Some(1_000),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        let message = crate::stream::final_message_from_stream(stream)
+            .await
+            .unwrap();
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(message.stop_reason, StopReason::Error);
+        assert!(
+            message.error_message.as_deref().is_some_and(
+                |error| error.contains("Server requested 277403s retry delay (max: 1s)")
+            )
+        );
+        assert!(
+            message
+                .error_message
+                .as_deref()
+                .is_some_and(|error| error.contains("rate limited"))
         );
     }
 

--- a/crates/ai/src/types.rs
+++ b/crates/ai/src/types.rs
@@ -234,7 +234,12 @@ pub struct StreamOptions {
     pub headers: ProviderHeaders,
     pub timeout_ms: Option<u64>,
     pub websocket_connect_timeout_ms: Option<u64>,
+    /// Maximum retry attempts for providers that support client-side retries.
     pub max_retries: Option<u32>,
+    /// Maximum delay in milliseconds to wait when the server requests a long
+    /// retry delay. If the requested delay exceeds this value, the request
+    /// fails immediately. Defaults to 60 seconds; set to zero to disable the
+    /// cap.
     pub max_retry_delay_ms: Option<u64>,
     pub http_client: Option<reqwest::Client>,
     pub metadata: Option<Value>,

--- a/crates/ai/src/utils/http.rs
+++ b/crates/ai/src/utils/http.rs
@@ -1,6 +1,7 @@
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use reqwest::{RequestBuilder, Response, StatusCode, header::HeaderMap};
+use ring::rand::{SecureRandom, SystemRandom};
 
 use crate::types::StreamOptions;
 use crate::{Error, Result};
@@ -39,19 +40,64 @@ where
         };
 
         match result {
-            Ok(response) if attempt < max_retries && is_retryable_status(response.status()) => {
-                sleep_before_retry(options, response.headers(), attempt).await?;
+            Ok(response) if attempt < max_retries && is_retryable_response(&response) => {
+                let delay_ms = match retry_delay_ms(
+                    response.headers(),
+                    attempt,
+                    options.max_retry_delay_ms,
+                ) {
+                    Ok(delay_ms) => delay_ms,
+                    Err(Error::Provider(message)) => {
+                        let status = response.status();
+                        let read_body = response.text();
+                        let body = if let Some(cancellation_token) =
+                            options.cancellation_token.as_ref()
+                        {
+                            tokio::select! {
+                                _ = cancellation_token.cancelled() => return Err(Error::Cancelled),
+                                body = read_body => body.unwrap_or_default(),
+                            }
+                        } else {
+                            read_body.await.unwrap_or_default()
+                        };
+                        return Err(Error::Provider(format!(
+                            "{message} {}",
+                            Error::ApiStatus { status, body }
+                        )));
+                    }
+                    Err(error) => return Err(error),
+                };
+                sleep_before_retry(options, delay_ms).await?;
                 attempt += 1;
             }
             Ok(response) => return Ok(response),
             Err(Error::Cancelled) => return Err(Error::Cancelled),
             Err(error) if attempt < max_retries => {
-                sleep_before_retry(options, &HeaderMap::new(), attempt).await?;
+                let delay_ms =
+                    retry_delay_ms(&HeaderMap::new(), attempt, options.max_retry_delay_ms)?;
+                sleep_before_retry(options, delay_ms).await?;
                 attempt += 1;
                 let _ = error;
             }
             Err(error) => return Err(error),
         }
+    }
+}
+
+/// Mirrors the pinned OpenAI/Anthropic SDK retry policy. Provider directives
+/// take precedence over the status-based fallback.
+fn is_retryable_response(response: &Response) -> bool {
+    if response.status().is_success() {
+        return false;
+    }
+    match response
+        .headers()
+        .get("x-should-retry")
+        .and_then(|value| value.to_str().ok())
+    {
+        Some("true") => true,
+        Some("false") => false,
+        _ => is_retryable_status(response.status()),
     }
 }
 
@@ -62,142 +108,149 @@ fn is_retryable_status(status: StatusCode) -> bool {
     ) || status.is_server_error()
 }
 
-async fn sleep_before_retry(
-    options: &StreamOptions,
-    headers: &HeaderMap,
-    attempt: u32,
-) -> Result<()> {
-    let delay_ms = retry_delay_ms(headers, attempt, options.max_retry_delay_ms);
-    if delay_ms == 0 {
+async fn sleep_before_retry(options: &StreamOptions, delay_ms: f64) -> Result<()> {
+    if delay_ms.is_nan() || delay_ms <= 0.0 {
         return Ok(());
     }
+    let delay = if delay_ms.is_finite() {
+        Duration::from_secs_f64(delay_ms / 1000.0)
+    } else {
+        Duration::MAX
+    };
 
     if let Some(cancellation_token) = options.cancellation_token.as_ref() {
         tokio::select! {
             _ = cancellation_token.cancelled() => Err(Error::Cancelled),
-            _ = tokio::time::sleep(Duration::from_millis(delay_ms)) => Ok(()),
+            _ = tokio::time::sleep(delay) => Ok(()),
         }
     } else {
-        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        tokio::time::sleep(delay).await;
         Ok(())
     }
 }
 
-fn retry_delay_ms(headers: &HeaderMap, attempt: u32, max_retry_delay_ms: Option<u64>) -> u64 {
-    let delay = retry_after_ms(headers).unwrap_or_else(|| exponential_delay_ms(attempt));
-    match max_retry_delay_ms {
-        Some(0) => delay,
-        Some(max) => delay.min(max),
-        None => delay.min(DEFAULT_MAX_RETRY_DELAY_MS),
+fn retry_delay_ms(
+    headers: &HeaderMap,
+    attempt: u32,
+    max_retry_delay_ms: Option<u64>,
+) -> Result<f64> {
+    let Some(delay_ms) = retry_after_ms(headers) else {
+        return Ok(exponential_delay_ms(attempt, random_unit_interval()));
+    };
+    let max_delay_ms = max_retry_delay_ms.unwrap_or(DEFAULT_MAX_RETRY_DELAY_MS);
+    if max_delay_ms > 0 && delay_ms > max_delay_ms as f64 {
+        let requested_seconds = (delay_ms / 1000.0).ceil();
+        let max_seconds = max_delay_ms.saturating_add(999) / 1000;
+        return Err(Error::Provider(format!(
+            "Server requested {requested_seconds}s retry delay (max: {max_seconds}s)."
+        )));
     }
+    Ok(delay_ms)
 }
 
-fn retry_after_ms(headers: &HeaderMap) -> Option<u64> {
+fn retry_after_ms(headers: &HeaderMap) -> Option<f64> {
     headers
         .get("retry-after-ms")
         .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.parse::<u64>().ok())
+        .and_then(parse_retry_delay_number)
         .or_else(|| {
             let value = headers
                 .get("retry-after")
                 .and_then(|value| value.to_str().ok())
-                .map(str::trim)?;
-            value
-                .parse::<u64>()
-                .ok()
-                .map(|seconds| seconds.saturating_mul(1000))
-                .or_else(|| retry_after_http_date_ms(value))
+                .filter(|value| !value.is_empty())?;
+            Some(
+                parse_retry_delay_seconds(value)
+                    .or_else(|| retry_after_http_date_ms(value.trim()))
+                    .unwrap_or(f64::NAN),
+            )
         })
 }
 
-fn exponential_delay_ms(attempt: u32) -> u64 {
-    500u64.saturating_mul(2u64.saturating_pow(attempt.min(6)))
+fn parse_retry_delay_number(value: &str) -> Option<f64> {
+    parse_float_prefix(value)
 }
 
-fn retry_after_http_date_ms(value: &str) -> Option<u64> {
-    let epoch_seconds = parse_imf_fixdate_epoch_seconds(value)?;
-    let target_ms = i128::from(epoch_seconds).saturating_mul(1000);
-    let now_ms = i128::from(crate::utils::time::now_millis());
-    Some(target_ms.saturating_sub(now_ms).max(0) as u64)
+fn parse_retry_delay_seconds(value: &str) -> Option<f64> {
+    parse_float_prefix(value).map(|seconds| seconds * 1000.0)
 }
 
-fn parse_imf_fixdate_epoch_seconds(value: &str) -> Option<i64> {
-    let parts: Vec<&str> = value.split_ascii_whitespace().collect();
-    let [weekday, day, month, year, time, zone] = parts.as_slice() else {
-        return None;
+/// Equivalent to JavaScript's `Number.parseFloat` for the decimal forms that
+/// can occur in HTTP headers. In particular, a valid numeric prefix is accepted.
+fn parse_float_prefix(value: &str) -> Option<f64> {
+    let value = value.trim_start();
+    let (sign, unsigned) = match value.as_bytes().first() {
+        Some(b'+') => (1.0, &value[1..]),
+        Some(b'-') => (-1.0, &value[1..]),
+        _ => (1.0, value),
     };
-    if !weekday.ends_with(',') || !zone.eq_ignore_ascii_case("GMT") {
+    if unsigned.starts_with("Infinity") {
+        return Some(sign * f64::INFINITY);
+    }
+    let bytes = value.as_bytes();
+    let mut end = usize::from(matches!(bytes.first(), Some(b'+' | b'-')));
+    let integer_start = end;
+    while bytes.get(end).is_some_and(u8::is_ascii_digit) {
+        end += 1;
+    }
+    let mut has_digit = end > integer_start;
+    if bytes.get(end) == Some(&b'.') {
+        end += 1;
+        let fraction_start = end;
+        while bytes.get(end).is_some_and(u8::is_ascii_digit) {
+            end += 1;
+        }
+        has_digit |= end > fraction_start;
+    }
+    if !has_digit {
         return None;
     }
 
-    let day = day.parse::<u32>().ok()?;
-    let month = parse_month(month)?;
-    let year = year.parse::<i32>().ok()?;
-    let (hour, minute, second) = parse_hms(time)?;
-    if day == 0 || day > days_in_month(year, month) || hour > 23 || minute > 59 || second > 59 {
-        return None;
+    if matches!(bytes.get(end), Some(b'e' | b'E')) {
+        let exponent_mark = end;
+        end += 1;
+        if matches!(bytes.get(end), Some(b'+' | b'-')) {
+            end += 1;
+        }
+        let exponent_start = end;
+        while bytes.get(end).is_some_and(u8::is_ascii_digit) {
+            end += 1;
+        }
+        if end == exponent_start {
+            end = exponent_mark;
+        }
     }
 
-    let days = days_from_civil(year, month, day);
-    Some(
-        days.saturating_mul(86_400)
-            .saturating_add(i64::from(hour) * 3600)
-            .saturating_add(i64::from(minute) * 60)
-            .saturating_add(i64::from(second)),
-    )
+    value[..end].parse().ok()
 }
 
-fn parse_month(value: &str) -> Option<u32> {
-    match value {
-        "Jan" => Some(1),
-        "Feb" => Some(2),
-        "Mar" => Some(3),
-        "Apr" => Some(4),
-        "May" => Some(5),
-        "Jun" => Some(6),
-        "Jul" => Some(7),
-        "Aug" => Some(8),
-        "Sep" => Some(9),
-        "Oct" => Some(10),
-        "Nov" => Some(11),
-        "Dec" => Some(12),
-        _ => None,
+fn exponential_delay_ms(attempt: u32, random: f64) -> f64 {
+    let exponential_delay = (500.0 * 2f64.powi(attempt.min(4) as i32)).min(8_000.0);
+    exponential_delay * (1.0 - random.clamp(0.0, 1.0) * 0.25)
+}
+
+fn random_unit_interval() -> f64 {
+    let mut bytes = [0; 8];
+    if SystemRandom::new().fill(&mut bytes).is_err() {
+        return 0.5;
     }
+
+    // Use the high 53 bits so every possible result is exactly representable
+    // as an f64 in the same [0, 1) range as Math.random().
+    let value = u64::from_ne_bytes(bytes) >> 11;
+    value as f64 / (1u64 << 53) as f64
 }
 
-fn parse_hms(value: &str) -> Option<(u32, u32, u32)> {
-    let mut parts = value.split(':');
-    let hour = parts.next()?.parse::<u32>().ok()?;
-    let minute = parts.next()?.parse::<u32>().ok()?;
-    let second = parts.next()?.parse::<u32>().ok()?;
-    if parts.next().is_some() {
-        return None;
+fn retry_after_http_date_ms(value: &str) -> Option<f64> {
+    let target_ms = system_time_epoch_ms(httpdate::parse_http_date(value).ok()?);
+    let now_ms = system_time_epoch_ms(SystemTime::now());
+    Some(target_ms.saturating_sub(now_ms) as f64)
+}
+
+fn system_time_epoch_ms(time: SystemTime) -> i128 {
+    match time.duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_millis() as i128,
+        Err(error) => -(error.duration().as_millis() as i128),
     }
-    Some((hour, minute, second))
-}
-
-fn days_in_month(year: i32, month: u32) -> u32 {
-    match month {
-        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
-        4 | 6 | 9 | 11 => 30,
-        2 if is_leap_year(year) => 29,
-        2 => 28,
-        _ => 0,
-    }
-}
-
-fn is_leap_year(year: i32) -> bool {
-    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
-}
-
-fn days_from_civil(year: i32, month: u32, day: u32) -> i64 {
-    let year = i64::from(year) - i64::from(month <= 2);
-    let era = if year >= 0 { year } else { year - 399 } / 400;
-    let year_of_era = year - era * 400;
-    let month_prime = i64::from(month) + if month > 2 { -3 } else { 9 };
-    let day_of_year = (153 * month_prime + 2) / 5 + i64::from(day) - 1;
-    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
-    era * 146_097 + day_of_era - 719_468
 }
 
 #[cfg(test)]
@@ -246,6 +299,198 @@ mod tests {
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn rejects_server_retry_delay_above_configured_cap_without_retrying() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let url = spawn_status_server(
+            Arc::clone(&attempts),
+            "429 Too Many Requests",
+            &[
+                ("retry-after", "277403"),
+                ("content-type", "application/json"),
+            ],
+            "",
+        )
+        .await;
+        let client = reqwest::Client::new();
+        let options = StreamOptions {
+            max_retries: Some(2),
+            max_retry_delay_ms: Some(1_000),
+            ..Default::default()
+        };
+
+        let error = send_with_retries(&options, || client.get(&url))
+            .await
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Server requested 277403s retry delay (max: 1s)")
+        );
+        assert!(error.to_string().contains("429 Too Many Requests"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rejects_server_retry_delay_above_default_cap() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let url = spawn_status_server(
+            Arc::clone(&attempts),
+            "503 Service Unavailable",
+            &[("retry-after", "61")],
+            "",
+        )
+        .await;
+        let client = reqwest::Client::new();
+        let options = StreamOptions {
+            max_retries: Some(1),
+            ..Default::default()
+        };
+
+        let error = send_with_retries(&options, || client.get(&url))
+            .await
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Server requested 61s retry delay (max: 60s)")
+        );
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn zero_disables_server_retry_delay_cap() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let url =
+            spawn_retry_server_with_headers(Arc::clone(&attempts), &[("retry-after-ms", "1")])
+                .await;
+        let client = reqwest::Client::new();
+        let options = StreamOptions {
+            max_retries: Some(1),
+            max_retry_delay_ms: Some(0),
+            ..Default::default()
+        };
+
+        let response = send_with_retries(&options, || client.get(&url))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancellation_interrupts_uncapped_server_backoff() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let url = spawn_status_server(
+            Arc::clone(&attempts),
+            "429 Too Many Requests",
+            &[("retry-after", "277403")],
+            "",
+        )
+        .await;
+        let client = reqwest::Client::new();
+        let cancellation_token = tokio_util::sync::CancellationToken::new();
+        let options = StreamOptions {
+            max_retries: Some(2),
+            max_retry_delay_ms: Some(0),
+            cancellation_token: Some(cancellation_token.clone()),
+            ..Default::default()
+        };
+        let request = send_with_retries(&options, || client.get(&url));
+        tokio::pin!(request);
+
+        tokio::select! {
+            result = &mut request => panic!("request finished before cancellation: {result:?}"),
+            _ = wait_for_attempts(&attempts, 1) => {}
+        }
+        cancellation_token.cancel();
+
+        assert!(matches!(request.await, Err(Error::Cancelled)));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn x_should_retry_false_prevents_retry() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let url = spawn_status_server(
+            Arc::clone(&attempts),
+            "429 Too Many Requests",
+            &[("x-should-retry", "false")],
+            "",
+        )
+        .await;
+        let client = reqwest::Client::new();
+        let options = StreamOptions {
+            max_retries: Some(2),
+            max_retry_delay_ms: Some(0),
+            ..Default::default()
+        };
+
+        let response = send_with_retries(&options, || client.get(&url))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn x_should_retry_true_allows_non_retryable_status() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let url = spawn_retry_server_with_status_and_headers(
+            Arc::clone(&attempts),
+            "400 Bad Request",
+            &[("x-should-retry", "true"), ("retry-after-ms", "0")],
+        )
+        .await;
+        let client = reqwest::Client::new();
+        let options = StreamOptions {
+            max_retries: Some(1),
+            ..Default::default()
+        };
+
+        let response = send_with_retries(&options, || client.get(&url))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn standard_retryable_statuses_remain_retryable() {
+        for status in [
+            "408 Request Timeout",
+            "409 Conflict",
+            "429 Too Many Requests",
+            "500 Internal Server Error",
+            "503 Service Unavailable",
+        ] {
+            let attempts = Arc::new(AtomicUsize::new(0));
+            let url = spawn_retry_server_with_status_and_headers(
+                Arc::clone(&attempts),
+                status,
+                &[("retry-after-ms", "0")],
+            )
+            .await;
+            let client = reqwest::Client::new();
+            let options = StreamOptions {
+                max_retries: Some(1),
+                ..Default::default()
+            };
+
+            let response = send_with_retries(&options, || client.get(&url))
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK, "status {status}");
+            assert_eq!(attempts.load(Ordering::SeqCst), 2, "status {status}");
+        }
+    }
+
     #[test]
     fn parses_retry_after_http_date() {
         let mut headers = HeaderMap::new();
@@ -256,7 +501,7 @@ mod tests {
 
         let delay_ms = retry_after_ms(&headers).unwrap();
 
-        assert!(delay_ms > DEFAULT_MAX_RETRY_DELAY_MS);
+        assert!(delay_ms > DEFAULT_MAX_RETRY_DELAY_MS as f64);
     }
 
     #[test]
@@ -267,7 +512,7 @@ mod tests {
             HeaderValue::from_static("Thu, 01 Jan 1970 00:00:00 GMT"),
         );
 
-        assert_eq!(retry_after_ms(&headers), Some(0));
+        assert!(retry_after_ms(&headers).is_some_and(|delay| delay < 0.0));
     }
 
     #[test]
@@ -279,28 +524,80 @@ mod tests {
             HeaderValue::from_static("Fri, 31 Dec 9999 23:59:59 GMT"),
         );
 
-        assert_eq!(retry_after_ms(&headers), Some(25));
+        assert_eq!(retry_after_ms(&headers), Some(25.0));
     }
 
     #[test]
-    fn parses_imf_fixdate_epoch_seconds() {
-        assert_eq!(
-            parse_imf_fixdate_epoch_seconds("Thu, 01 Jan 1970 00:00:00 GMT"),
-            Some(0)
-        );
-        assert_eq!(
-            parse_imf_fixdate_epoch_seconds("Wed, 21 Oct 2015 07:28:00 GMT"),
-            Some(1_445_412_480)
-        );
-        assert_eq!(
-            parse_imf_fixdate_epoch_seconds("Wed, 31 Feb 2015 07:28:00 GMT"),
-            None
-        );
+    fn parses_fractional_provider_retry_delays_like_pi() {
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after-ms", HeaderValue::from_static("25.1"));
+        assert_eq!(retry_after_ms(&headers), Some(25.1));
+
+        headers.remove("retry-after-ms");
+        headers.insert("retry-after", HeaderValue::from_static("0.025"));
+        assert_eq!(retry_after_ms(&headers), Some(25.0));
+    }
+
+    #[test]
+    fn parses_numeric_prefixes_like_javascript_parse_float() {
+        assert_eq!(parse_float_prefix("  -1.5e2junk"), Some(-150.0));
+        assert_eq!(parse_float_prefix("1e+oops"), Some(1.0));
+        assert_eq!(parse_float_prefix(".25 seconds"), Some(0.25));
+        assert_eq!(parse_float_prefix("Infinity"), Some(f64::INFINITY));
+        assert_eq!(parse_float_prefix("junk1.5"), None);
+    }
+
+    #[test]
+    fn invalid_retry_after_is_an_immediate_delay_like_javascript() {
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", HeaderValue::from_static("not-a-date"));
+
+        assert!(retry_after_ms(&headers).is_some_and(f64::is_nan));
+    }
+
+    #[test]
+    fn empty_retry_after_uses_exponential_fallback_like_javascript() {
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", HeaderValue::from_static(""));
+
+        assert!(retry_after_ms(&headers).is_none());
+    }
+
+    #[test]
+    fn exponential_backoff_matches_pi_curve_and_jitter() {
+        assert_eq!(exponential_delay_ms(0, 0.0), 500.0);
+        assert_eq!(exponential_delay_ms(0, 1.0), 375.0);
+        assert_eq!(exponential_delay_ms(1, 0.0), 1_000.0);
+        assert_eq!(exponential_delay_ms(4, 0.0), 8_000.0);
+        assert_eq!(exponential_delay_ms(4, 1.0), 6_000.0);
+        assert_eq!(exponential_delay_ms(20, 0.0), 8_000.0);
+        assert_eq!(exponential_delay_ms(20, 1.0), 6_000.0);
     }
 
     async fn spawn_retry_server(attempts: Arc<AtomicUsize>) -> String {
+        spawn_retry_server_with_headers(attempts, &[("retry-after-ms", "0")]).await
+    }
+
+    async fn spawn_retry_server_with_headers(
+        attempts: Arc<AtomicUsize>,
+        headers: &[(&str, &str)],
+    ) -> String {
+        spawn_retry_server_with_status_and_headers(attempts, "500 Internal Server Error", headers)
+            .await
+    }
+
+    async fn spawn_retry_server_with_status_and_headers(
+        attempts: Arc<AtomicUsize>,
+        status: &str,
+        headers: &[(&str, &str)],
+    ) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
+        let status = status.to_string();
+        let headers = headers
+            .iter()
+            .map(|(name, value)| format!("{name}: {value}\r\n"))
+            .collect::<String>();
         tokio::spawn(async move {
             loop {
                 let Ok((mut socket, _)) = listener.accept().await else {
@@ -310,13 +607,53 @@ mod tests {
                 let mut buffer = vec![0u8; 1024];
                 let _ = socket.read(&mut buffer).await;
                 let response = if attempt == 0 {
-                    "HTTP/1.1 500 Internal Server Error\r\nretry-after-ms: 0\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                    format!(
+                        "HTTP/1.1 {status}\r\n{headers}content-length: 0\r\nconnection: close\r\n\r\n"
+                    )
                 } else {
-                    "HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                    "HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n".to_string()
                 };
                 let _ = socket.write_all(response.as_bytes()).await;
             }
         });
         format!("http://{addr}")
+    }
+
+    async fn spawn_status_server(
+        attempts: Arc<AtomicUsize>,
+        status: &str,
+        headers: &[(&str, &str)],
+        body: &str,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let status = status.to_string();
+        let headers = headers
+            .iter()
+            .map(|(name, value)| format!("{name}: {value}\r\n"))
+            .collect::<String>();
+        let body = body.to_string();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                attempts.fetch_add(1, Ordering::SeqCst);
+                let mut buffer = vec![0u8; 1024];
+                let _ = socket.read(&mut buffer).await;
+                let response = format!(
+                    "HTTP/1.1 {status}\r\n{headers}content-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    async fn wait_for_attempts(attempts: &AtomicUsize, expected: usize) {
+        while attempts.load(Ordering::SeqCst) < expected {
+            tokio::task::yield_now().await;
+        }
     }
 }


### PR DESCRIPTION
## Summary

- align retry classification and provider-directed delay handling with pi
- use pi-compatible bounded exponential backoff with downward jitter and abortable waits
- preserve provider error context when rejecting delays above the configured limit
- cover retry behavior at both the shared HTTP helper and OpenAI Completions provider levels

## Verification

- `mise run all`
- 422 `ai` crate tests passed
- 5 example tests passed
- formatting, workspace check, and clippy with warnings denied passed