### PR TITLE
feat: report detailed usage and tiered costs

### DIFF
--- a/crates/ai/src/models.rs
+++ b/crates/ai/src/models.rs
@@ -10,10 +10,34 @@ const EXTENDED_THINKING_LEVELS: [ModelThinkingLevel; 7] = [
     ModelThinkingLevel::Max,
 ];
 pub fn calculate_cost(model: &Model, usage: &mut Usage) -> UsageCost {
-    usage.cost.input = (model.cost.input / 1_000_000.0) * usage.input as f64;
-    usage.cost.output = (model.cost.output / 1_000_000.0) * usage.output as f64;
-    usage.cost.cache_read = (model.cost.cache_read / 1_000_000.0) * usage.cache_read as f64;
-    usage.cost.cache_write = (model.cost.cache_write / 1_000_000.0) * usage.cache_write as f64;
+    let input_tokens =
+        u64::from(usage.input) + u64::from(usage.cache_read) + u64::from(usage.cache_write);
+    let mut input_rate = model.cost.input;
+    let mut output_rate = model.cost.output;
+    let mut cache_read_rate = model.cost.cache_read;
+    let mut cache_write_rate = model.cost.cache_write;
+    let mut matched_threshold = None;
+    for tier in &model.cost.tiers {
+        if input_tokens > u64::from(tier.input_tokens_above)
+            && matched_threshold.is_none_or(|threshold| tier.input_tokens_above > threshold)
+        {
+            input_rate = tier.input;
+            output_rate = tier.output;
+            cache_read_rate = tier.cache_read;
+            cache_write_rate = tier.cache_write;
+            matched_threshold = Some(tier.input_tokens_above);
+        }
+    }
+
+    // Anthropic charges 2x the base input rate for one-hour cache writes.
+    let long_write = usage.cache_write_1h.unwrap_or(0);
+    let short_write = usage.cache_write.saturating_sub(long_write);
+    usage.cost.input = (input_rate / 1_000_000.0) * usage.input as f64;
+    usage.cost.output = (output_rate / 1_000_000.0) * usage.output as f64;
+    usage.cost.cache_read = (cache_read_rate / 1_000_000.0) * usage.cache_read as f64;
+    usage.cost.cache_write = (cache_write_rate * short_write as f64
+        + input_rate * 2.0 * long_write as f64)
+        / 1_000_000.0;
     usage.cost.total =
         usage.cost.input + usage.cost.output + usage.cost.cache_read + usage.cost.cache_write;
     usage.cost.clone()
@@ -81,6 +105,92 @@ pub fn models_are_equal(a: Option<&Model>, b: Option<&Model>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::{ModelCost, ModelCostTier, Usage};
+
+    fn tiered_model() -> Model {
+        Model {
+            cost: ModelCost {
+                input: 5.0,
+                output: 30.0,
+                cache_read: 0.5,
+                cache_write: 6.25,
+                tiers: vec![ModelCostTier {
+                    input_tokens_above: 272_000,
+                    input: 10.0,
+                    output: 45.0,
+                    cache_read: 1.0,
+                    cache_write: 12.5,
+                }],
+            },
+            ..Model::default()
+        }
+    }
+
+    #[test]
+    fn applies_request_wide_pricing_tiers_above_the_input_threshold() {
+        let model = tiered_model();
+        let mut short = Usage {
+            input: 200_000,
+            output: 100_000,
+            cache_read: 72_000,
+            ..Usage::default()
+        };
+        let mut long = Usage {
+            cache_write: 1,
+            ..short.clone()
+        };
+
+        let short_cost = calculate_cost(&model, &mut short);
+        assert_eq!(short_cost.input, 1.0);
+        assert_eq!(short_cost.output, 3.0);
+        assert_eq!(short_cost.cache_read, 0.036);
+        assert_eq!(short_cost.cache_write, 0.0);
+
+        let long_cost = calculate_cost(&model, &mut long);
+        assert_eq!(long_cost.input, 2.0);
+        assert_eq!(long_cost.output, 4.5);
+        assert_eq!(long_cost.cache_read, 0.072);
+        assert_eq!(long_cost.cache_write, 0.0000125);
+    }
+
+    #[test]
+    fn highest_matching_tier_applies_and_threshold_is_strict() {
+        let mut model = tiered_model();
+        model.cost.tiers.push(ModelCostTier {
+            input_tokens_above: 400_000,
+            input: 20.0,
+            output: 60.0,
+            cache_read: 2.0,
+            cache_write: 25.0,
+        });
+        let mut at_threshold = Usage {
+            input: 272_000,
+            ..Usage::default()
+        };
+        let mut above_both = Usage {
+            input: 400_001,
+            output: 1_000_000,
+            ..Usage::default()
+        };
+
+        assert_eq!(calculate_cost(&model, &mut at_threshold).input, 1.36);
+        assert_eq!(calculate_cost(&model, &mut above_both).output, 60.0);
+    }
+
+    #[test]
+    fn prices_anthropic_one_hour_cache_writes_at_twice_input() {
+        let mut model = tiered_model();
+        model.cost.tiers.clear();
+        let mut usage = Usage {
+            cache_write: 1_000_000,
+            cache_write_1h: Some(400_000),
+            ..Usage::default()
+        };
+
+        let cost = calculate_cost(&model, &mut usage);
+
+        assert_eq!(cost.cache_write, 7.75);
+    }
 
     #[test]
     fn model_equality_distinguishes_api_mode() {

--- a/crates/ai/src/providers/anthropic.rs
+++ b/crates/ai/src/providers/anthropic.rs
@@ -519,7 +519,7 @@ async fn run_stream(
                     output.response_id = Some(id.to_string());
                 }
                 if let Some(usage) = parsed.pointer("/message/usage") {
-                    update_anthropic_usage(&mut output, usage, &model);
+                    update_anthropic_start_usage(&mut output, usage, &model);
                 }
             }
             Some("content_block_start") => {
@@ -1119,6 +1119,19 @@ fn update_anthropic_usage(output: &mut AssistantMessage, usage: &Value, model: &
     calculate_cost(model, &mut output.usage);
 }
 
+fn update_anthropic_start_usage(output: &mut AssistantMessage, usage: &Value, model: &Model) {
+    // pi exposes this provider-supported breakdown as zero when Anthropic
+    // omits it from message_start, while leaving it absent for providers that
+    // do not report the breakdown at all.
+    output.usage.cache_write_1h = Some(
+        usage
+            .pointer("/cache_creation/ephemeral_1h_input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32,
+    );
+    update_anthropic_usage(output, usage, model);
+}
+
 fn get_anthropic_compat(model: &Model) -> ResolvedAnthropicCompat {
     let compat = &model.compat.anthropic_messages;
     ResolvedAnthropicCompat {
@@ -1439,13 +1452,13 @@ mod tests {
         };
         let mut output = AssistantMessage::empty_for(&model);
 
-        update_anthropic_usage(
+        update_anthropic_start_usage(
             &mut output,
             &json!({ "cache_creation_input_tokens": 1_000_000 }),
             &model,
         );
 
-        assert_eq!(output.usage.cache_write_1h, None);
+        assert_eq!(output.usage.cache_write_1h, Some(0));
         assert_eq!(output.usage.cost.cache_write, 6.25);
     }
 

--- a/crates/ai/src/providers/anthropic.rs
+++ b/crates/ai/src/providers/anthropic.rs
@@ -1100,6 +1100,18 @@ fn update_anthropic_usage(output: &mut AssistantMessage, usage: &Value, model: &
     {
         output.usage.cache_write = cache_write as u32;
     }
+    if let Some(cache_write_1h) = usage
+        .pointer("/cache_creation/ephemeral_1h_input_tokens")
+        .and_then(Value::as_u64)
+    {
+        output.usage.cache_write_1h = Some(cache_write_1h as u32);
+    }
+    if let Some(reasoning) = usage
+        .pointer("/output_tokens_details/thinking_tokens")
+        .and_then(Value::as_u64)
+    {
+        output.usage.reasoning = Some(reasoning as u32);
+    }
     output.usage.total_tokens = output.usage.input
         + output.usage.output
         + output.usage.cache_read
@@ -1380,6 +1392,161 @@ mod tests {
             max_tokens: 1024,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn prices_one_hour_cache_writes_and_reports_reasoning_usage() {
+        let mut model = anthropic_model("claude-opus-4-8");
+        model.cost = ModelCost {
+            input: 5.0,
+            output: 25.0,
+            cache_read: 0.5,
+            cache_write: 6.25,
+            ..Default::default()
+        };
+        let mut output = AssistantMessage::empty_for(&model);
+
+        update_anthropic_usage(
+            &mut output,
+            &json!({
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 1_000_000,
+                "cache_creation": {
+                    "ephemeral_5m_input_tokens": 600_000,
+                    "ephemeral_1h_input_tokens": 400_000
+                },
+                "output_tokens_details": { "thinking_tokens": 40 }
+            }),
+            &model,
+        );
+
+        assert_eq!(output.usage.cache_write, 1_000_000);
+        assert_eq!(output.usage.cache_write_1h, Some(400_000));
+        assert_eq!(output.usage.reasoning, Some(40));
+        assert_eq!(output.usage.output, 50);
+        assert_eq!(output.usage.cost.cache_write, 7.75);
+    }
+
+    #[test]
+    fn cache_write_pricing_falls_back_when_anthropic_omits_breakdown() {
+        let mut model = anthropic_model("claude-opus-4-8");
+        model.cost = ModelCost {
+            input: 5.0,
+            cache_write: 6.25,
+            ..Default::default()
+        };
+        let mut output = AssistantMessage::empty_for(&model);
+
+        update_anthropic_usage(
+            &mut output,
+            &json!({ "cache_creation_input_tokens": 1_000_000 }),
+            &model,
+        );
+
+        assert_eq!(output.usage.cache_write_1h, None);
+        assert_eq!(output.usage.cost.cache_write, 6.25);
+    }
+
+    #[tokio::test]
+    async fn anthropic_stream_reports_reasoning_and_one_hour_cache_write_usage() {
+        let body = sse_body(&[
+            (
+                "message_start",
+                json!({
+                    "type": "message_start",
+                    "message": {
+                        "id": "msg_usage",
+                        "usage": {
+                            "input_tokens": 100,
+                            "output_tokens": 0,
+                            "cache_read_input_tokens": 0,
+                            "cache_creation_input_tokens": 1_000_000,
+                            "cache_creation": {
+                                "ephemeral_5m_input_tokens": 600_000,
+                                "ephemeral_1h_input_tokens": 400_000
+                            }
+                        }
+                    }
+                })
+                .to_string(),
+            ),
+            (
+                "content_block_start",
+                json!({
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": { "type": "text", "text": "" }
+                })
+                .to_string(),
+            ),
+            (
+                "content_block_delta",
+                json!({
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": { "type": "text_delta", "text": "Hi" }
+                })
+                .to_string(),
+            ),
+            (
+                "content_block_stop",
+                json!({ "type": "content_block_stop", "index": 0 }).to_string(),
+            ),
+            (
+                "message_delta",
+                json!({
+                    "type": "message_delta",
+                    "delta": { "stop_reason": "end_turn" },
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 1_000_000,
+                        "output_tokens_details": { "thinking_tokens": 40 }
+                    }
+                })
+                .to_string(),
+            ),
+            (
+                "message_stop",
+                json!({ "type": "message_stop" }).to_string(),
+            ),
+        ]);
+        let mut model = anthropic_model("claude-opus-4-8");
+        model.base_url = spawn_sse_server(body).await;
+        model.cost = ModelCost {
+            input: 5.0,
+            output: 25.0,
+            cache_read: 0.5,
+            cache_write: 6.25,
+            ..Default::default()
+        };
+
+        let result = crate::stream::final_message_from_stream(stream_anthropic(
+            model,
+            Context {
+                messages: vec![crate::types::Message::user_text("hi")],
+                ..Default::default()
+            },
+            AnthropicOptions {
+                base: StreamOptions {
+                    api_key: Some("test-key".to_string()),
+                    cache_retention: Some(CacheRetention::None),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ))
+        .await
+        .unwrap();
+
+        assert_eq!(result.usage.output, 50);
+        assert_eq!(result.usage.reasoning, Some(40));
+        assert_eq!(result.usage.cache_write, 1_000_000);
+        assert_eq!(result.usage.cache_write_1h, Some(400_000));
+        assert_eq!(result.usage.cost.cache_write, 7.75);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/ai/src/providers/faux.rs
+++ b/crates/ai/src/providers/faux.rs
@@ -690,6 +690,8 @@ fn default_usage() -> Usage {
         output: 0,
         cache_read: 0,
         cache_write: 0,
+        cache_write_1h: None,
+        reasoning: None,
         total_tokens: 0,
         cost: UsageCost::default(),
     }
@@ -855,6 +857,8 @@ fn with_usage_estimate(
         output: output_tokens,
         cache_read,
         cache_write,
+        cache_write_1h: None,
+        reasoning: None,
         total_tokens: input + output_tokens + cache_read + cache_write,
         cost: UsageCost::default(),
     };

--- a/crates/ai/src/providers/openai_completions.rs
+++ b/crates/ai/src/providers/openai_completions.rs
@@ -1111,6 +1111,10 @@ fn parse_chunk_usage(raw: &Value, model: &Model) -> Usage {
         .and_then(|details| details.get("cache_write_tokens"))
         .and_then(Value::as_u64)
         .unwrap_or(0) as u32;
+    let reasoning = raw
+        .pointer("/completion_tokens_details/reasoning_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as u32;
     let mut usage = Usage {
         input: prompt_tokens
             .saturating_sub(cache_read)
@@ -1118,6 +1122,8 @@ fn parse_chunk_usage(raw: &Value, model: &Model) -> Usage {
         output: completion_tokens,
         cache_read,
         cache_write,
+        cache_write_1h: None,
+        reasoning: Some(reasoning),
         total_tokens: prompt_tokens + completion_tokens,
         cost: Default::default(),
     };
@@ -3198,6 +3204,7 @@ mod tests {
             .unwrap();
         assert_eq!(message.usage.input, 10);
         assert_eq!(message.usage.output, 33);
+        assert_eq!(message.usage.reasoning, Some(21));
         assert_eq!(message.usage.total_tokens, 43);
     }
 

--- a/crates/ai/src/providers/openai_responses.rs
+++ b/crates/ai/src/providers/openai_responses.rs
@@ -1113,11 +1113,23 @@ fn parse_response_usage(raw: &Value, model: &Model) -> Usage {
         .pointer("/input_tokens_details/cached_tokens")
         .and_then(Value::as_u64)
         .unwrap_or(0) as u32;
+    let cache_write_tokens = raw
+        .pointer("/input_tokens_details/cache_write_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as u32;
+    let reasoning = raw
+        .pointer("/output_tokens_details/reasoning_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as u32;
     let mut usage = Usage {
-        input: input_tokens.saturating_sub(cached_tokens),
+        input: input_tokens
+            .saturating_sub(cached_tokens)
+            .saturating_sub(cache_write_tokens),
         output: output_tokens,
         cache_read: cached_tokens,
-        cache_write: 0,
+        cache_write: cache_write_tokens,
+        cache_write_1h: None,
+        reasoning: Some(reasoning),
         total_tokens: raw.get("total_tokens").and_then(Value::as_u64).unwrap_or(0) as u32,
         cost: Default::default(),
     };
@@ -2844,6 +2856,7 @@ mod tests {
             output: 4.0,
             cache_read: 0.0,
             cache_write: 0.0,
+            tiers: Vec::new(),
         };
 
         let stream = stream_openai_responses(
@@ -3151,6 +3164,31 @@ mod tests {
             assert_eq!(usage.cost.cache_write, 3.0 * multiplier);
             assert_eq!(usage.cost.total, 10.0 * multiplier);
         }
+    }
+
+    #[test]
+    fn response_usage_reports_reasoning_and_separate_cache_writes() {
+        let model = model();
+        let usage = parse_response_usage(
+            &json!({
+                "input_tokens": 100,
+                "output_tokens": 33,
+                "total_tokens": 133,
+                "input_tokens_details": {
+                    "cached_tokens": 50,
+                    "cache_write_tokens": 30
+                },
+                "output_tokens_details": { "reasoning_tokens": 21 }
+            }),
+            &model,
+        );
+
+        assert_eq!(usage.input, 20);
+        assert_eq!(usage.cache_read, 50);
+        assert_eq!(usage.cache_write, 30);
+        assert_eq!(usage.output, 33);
+        assert_eq!(usage.reasoning, Some(21));
+        assert_eq!(usage.total_tokens, 133);
     }
 
     #[tokio::test]

--- a/crates/ai/src/types.rs
+++ b/crates/ai/src/types.rs
@@ -392,6 +392,14 @@ pub struct Usage {
     pub output: u32,
     pub cache_read: u32,
     pub cache_write: u32,
+    /// Subset of `cache_write` written with one-hour retention. Only
+    /// Anthropic reports this split.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_write_1h: Option<u32>,
+    /// Reasoning/thinking tokens when the provider reports them. This is a
+    /// subset of `output`, which already includes these tokens.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<u32>,
     pub total_tokens: u32,
     pub cost: UsageCost,
 }
@@ -961,11 +969,36 @@ pub enum ModelOutput {
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ModelCostRates {
+    pub input: f64,
+    pub output: f64,
+    pub cache_read: f64,
+    pub cache_write: f64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelCostTier {
+    /// Use this tier for requests whose total input usage exceeds this token
+    /// count.
+    pub input_tokens_above: u32,
+    pub input: f64,
+    pub output: f64,
+    pub cache_read: f64,
+    pub cache_write: f64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ModelCost {
     pub input: f64,
     pub output: f64,
     pub cache_read: f64,
     pub cache_write: f64,
+    /// Request-wide pricing tiers. The highest matching input threshold
+    /// applies to the full request.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tiers: Vec<ModelCostTier>,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize)]
@@ -1610,6 +1643,47 @@ mod tests {
         assert_eq!(
             serde_json::to_value(headers).unwrap(),
             json!({ "x-keep": "value", "x-remove": null })
+        );
+    }
+
+    #[test]
+    fn usage_optional_breakdowns_and_cost_tiers_round_trip() {
+        let usage = Usage {
+            output: 20,
+            cache_write: 10,
+            cache_write_1h: Some(4),
+            reasoning: Some(7),
+            ..Default::default()
+        };
+        let serialized_usage = serde_json::to_value(&usage).unwrap();
+        assert_eq!(serialized_usage["cacheWrite1h"], json!(4));
+        assert_eq!(serialized_usage["reasoning"], json!(7));
+        assert_eq!(
+            serde_json::from_value::<Usage>(serialized_usage).unwrap(),
+            usage
+        );
+        let empty_usage = serde_json::to_value(Usage::default()).unwrap();
+        assert!(empty_usage.get("cacheWrite1h").is_none());
+        assert!(empty_usage.get("reasoning").is_none());
+
+        let cost = ModelCost {
+            input: 5.0,
+            output: 30.0,
+            cache_read: 0.5,
+            cache_write: 6.25,
+            tiers: vec![ModelCostTier {
+                input_tokens_above: 272_000,
+                input: 10.0,
+                output: 45.0,
+                cache_read: 1.0,
+                cache_write: 12.5,
+            }],
+        };
+        let serialized_cost = serde_json::to_value(&cost).unwrap();
+        assert_eq!(serialized_cost["tiers"][0]["inputTokensAbove"], 272_000);
+        assert_eq!(
+            serde_json::from_value::<ModelCost>(serialized_cost).unwrap(),
+            cost
         );
     }
 

--- a/crates/ai/src/utils/overflow.rs
+++ b/crates/ai/src/utils/overflow.rs
@@ -128,6 +128,8 @@ mod tests {
                 output,
                 cache_read,
                 cache_write: 0,
+                cache_write_1h: None,
+                reasoning: None,
                 total_tokens: input + cache_read + output,
                 cost: UsageCost::default(),
             },


### PR DESCRIPTION
## Summary

- report provider reasoning-token usage without double-counting output totals
- preserve OpenAI cache-read and cache-write usage and price Anthropic one-hour cache writes accurately
- add request-wide input-token pricing tiers using the highest matching threshold
- keep optional usage fields serde-compatible and preserve existing service-tier pricing

## Verification

- `mise run all`
- 430 `ai` crate tests passed
- 5 example tests passed
- formatting, workspace check, and clippy with warnings denied passed
- no dependency or lockfile changes were required