### PR TITLE
feat: add embedding support

### DIFF
--- a/crates/ai/README.md
+++ b/crates/ai/README.md
@@ -18,6 +18,7 @@ and a lightweight agent loop, inspired by [`pi`](https://github.com/earendil-wor
 - [Image Generation](#image-generation)
   - [Basic Image Generation](#basic-image-generation)
   - [Notes and Limitations](#notes-and-limitations)
+- [Embeddings](#embeddings)
 - [Thinking/Reasoning](#thinkingreasoning)
   - [Unified Interface](#unified-interface-streamsimplecompletesimple)
   - [Provider-Specific Options](#provider-specific-options-streamcomplete)
@@ -75,7 +76,7 @@ and a lightweight agent loop, inspired by [`pi`](https://github.com/earendil-wor
 
 ## Supported Providers
 
-- **OpenAI** via Chat Completions, Responses, and Images
+- **OpenAI** via Chat Completions, Responses, Images, and Embeddings
 - **Anthropic** via Messages
 - **GitHub Copilot** through OAuth-backed OpenAI/Anthropic-compatible routes
 - **OpenRouter** for image generation
@@ -92,6 +93,9 @@ The active built-in image generation APIs are:
 
 - `openai-images`
 - `openrouter-images`
+
+The active built-in embedding API is `openai-embeddings`, available through
+OpenAI-compatible and GitHub Copilot provider handles.
 
 The active built-in provider handles are focused on `openai`, `anthropic`, and
 `github_copilot` for chat, plus `openai` and `openrouter` for image generation. Azure
@@ -562,6 +566,31 @@ implemented yet. OpenRouter image input and text output are opt-in model
 capabilities configured by the caller. Provider errors are returned as
 `AssistantImages` with `stop_reason: ImagesStopReason::Error`; cancelled
 requests use `ImagesStopReason::Aborted`.
+
+## Embeddings
+
+Use `embed` for one string and `embed_many` for multiple strings. Both call
+the OpenAI-compatible `/embeddings` endpoint. A single input is sent upstream
+as a one-item array for compatibility with providers that reject scalar input.
+Both functions are asynchronous and return a complete result rather than a
+stream.
+
+```rust
+use ai::{embed, embed_many, providers::openai, Result};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let openai = openai::from_env()?;
+    let model = openai
+        .embedding_model("text-embedding-3-small")
+        .build_embedding()?;
+
+    let one = embed(model.clone(), "hello", None).await?;
+    let batch = embed_many(model, ["first", "second"], None).await?;
+    println!("single: {:?}, batch: {}", one.embedding, batch.embeddings.len());
+    Ok(())
+}
+```
 
 ## Thinking/Reasoning
 

--- a/crates/ai/README.md
+++ b/crates/ai/README.md
@@ -572,8 +572,6 @@ requests use `ImagesStopReason::Aborted`.
 Use `embed` for one string and `embed_many` for multiple strings. Both call
 the OpenAI-compatible `/embeddings` endpoint. A single input is sent upstream
 as a one-item array for compatibility with providers that reject scalar input.
-Both functions are asynchronous and return a complete result rather than a
-stream.
 
 ```rust
 use ai::{embed, embed_many, providers::openai, Result};

--- a/crates/ai/src/embeddings.rs
+++ b/crates/ai/src/embeddings.rs
@@ -1,0 +1,54 @@
+use crate::types::{Embedding, EmbeddingBatch, EmbeddingOptions, Model};
+use crate::{Error, Result};
+
+pub async fn embed(
+    model: Model,
+    input: impl Into<String>,
+    options: Option<EmbeddingOptions>,
+) -> Result<Embedding> {
+    let batch = embed_many(model, [input.into()], options).await?;
+    let embedding = batch.embeddings.into_iter().next().ok_or_else(|| {
+        Error::InvalidProviderResponse("embedding response contained no data".to_string())
+    })?;
+    Ok(Embedding {
+        embedding,
+        model: batch.model,
+        usage: batch.usage,
+    })
+}
+
+pub async fn embed_many<I, S>(
+    model: Model,
+    inputs: I,
+    options: Option<EmbeddingOptions>,
+) -> Result<EmbeddingBatch>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let inputs = inputs.into_iter().map(Into::into).collect::<Vec<_>>();
+    if inputs.is_empty() {
+        return Err(Error::Validation(
+            "embedding input must contain at least one string".to_string(),
+        ));
+    }
+    let api = model
+        .embedding_api()
+        .ok_or_else(|| Error::unsupported_capability(model.provider.clone(), "embedding models"))?;
+    api.embed_many(model, inputs, options.unwrap_or_default())
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn embed_many_rejects_empty_input_before_provider_dispatch() {
+        let error = embed_many(Model::default(), Vec::<String>::new(), None)
+            .await
+            .expect_err("empty input should fail");
+
+        assert!(matches!(error, Error::Validation(_)));
+    }
+}

--- a/crates/ai/src/error.rs
+++ b/crates/ai/src/error.rs
@@ -32,6 +32,9 @@ pub enum Error {
     #[error("provider error: {0}")]
     Provider(String),
 
+    #[error("invalid provider response: {0}")]
+    InvalidProviderResponse(String),
+
     #[error("{0}")]
     Validation(String),
 

--- a/crates/ai/src/lib.rs
+++ b/crates/ai/src/lib.rs
@@ -2,6 +2,7 @@ pub mod agent;
 pub mod agent_error;
 pub mod agent_loop;
 pub mod agent_types;
+pub mod embeddings;
 pub mod env_api_keys;
 pub mod error;
 pub mod event_stream;
@@ -24,6 +25,7 @@ pub use agent_loop::{
     AgentEventStream, agent_loop, agent_loop_continue, run_agent_loop, run_agent_loop_continue,
 };
 pub use agent_types::*;
+pub use embeddings::{embed, embed_many};
 pub use env_api_keys::{
     ANTHROPIC_API_KEY_ENV_VAR, ANTHROPIC_AUTH_TOKEN_ENV_VAR, ANTHROPIC_OAUTH_TOKEN_ENV_VAR,
     GITHUB_COPILOT_TOKEN_ENV_VAR, KnownProvider, OPENAI_API_KEY_ENV_VAR,
@@ -49,7 +51,10 @@ pub use oauth::{
     refresh_anthropic_token, refresh_github_copilot_token, refresh_oauth_token,
     register_oauth_provider, reset_oauth_providers, unregister_oauth_provider,
 };
-pub use provider::{ImageModelApi, LanguageModelApi, ModelBuilder, Provider, ProviderCapabilities};
+pub use provider::{
+    EmbeddingModelApi, ImageModelApi, LanguageModelApi, ModelBuilder, Provider,
+    ProviderCapabilities,
+};
 pub use providers::anthropic::{
     Anthropic, AnthropicEffort, AnthropicOptions, AnthropicThinkingDisplay, stream_anthropic,
     stream_simple_anthropic,

--- a/crates/ai/src/provider.rs
+++ b/crates/ai/src/provider.rs
@@ -5,8 +5,9 @@ use reqwest::header::{HeaderName, HeaderValue};
 
 use crate::event_stream::AssistantEventStream;
 use crate::types::{
-    AssistantImages, Context, ImageGenerationOptions, ImagesContext, Model, ModelCompat, ModelCost,
-    ModelInput, ModelOutput, SimpleStreamOptions, StreamOptions,
+    AssistantImages, Context, EmbeddingBatch, EmbeddingOptions, ImageGenerationOptions,
+    ImagesContext, Model, ModelCompat, ModelCost, ModelInput, ModelOutput, SimpleStreamOptions,
+    StreamOptions,
 };
 use crate::{Error, Result};
 
@@ -14,6 +15,7 @@ use crate::{Error, Result};
 pub struct ProviderCapabilities {
     pub language_models: bool,
     pub image_models: bool,
+    pub embedding_models: bool,
 }
 
 pub trait Provider: dyn_clone::DynClone + Send + Sync + 'static {
@@ -62,6 +64,20 @@ pub trait ImageModelApi: dyn_clone::DynClone + Send + Sync + 'static {
 
 dyn_clone::clone_trait_object!(ImageModelApi);
 
+#[async_trait]
+pub trait EmbeddingModelApi: dyn_clone::DynClone + Send + Sync + 'static {
+    fn id(&self) -> &str;
+
+    async fn embed_many(
+        &self,
+        model: Model,
+        inputs: Vec<String>,
+        options: EmbeddingOptions,
+    ) -> Result<EmbeddingBatch>;
+}
+
+dyn_clone::clone_trait_object!(EmbeddingModelApi);
+
 #[derive(Clone)]
 pub struct ModelBuilder {
     model: Model,
@@ -99,6 +115,19 @@ impl ModelBuilder {
                 api: api.id().to_string(),
                 provider: provider_id.to_string(),
                 image_api: Some(api),
+                ..Model::default()
+            },
+        }
+    }
+
+    pub fn new_embedding(provider_id: &str, id: &str, api: Arc<dyn EmbeddingModelApi>) -> Self {
+        Self {
+            model: Model {
+                id: id.to_string(),
+                name: id.to_string(),
+                api: api.id().to_string(),
+                provider: provider_id.to_string(),
+                embedding_api: Some(api),
                 ..Model::default()
             },
         }
@@ -167,10 +196,13 @@ impl ModelBuilder {
     }
 
     pub fn build(self) -> Result<Model> {
-        if self.model.language_api.is_none() && self.model.image_api.is_none() {
+        if self.model.language_api.is_none()
+            && self.model.image_api.is_none()
+            && self.model.embedding_api.is_none()
+        {
             return Err(Error::unsupported_capability(
                 self.model.provider,
-                "language or image models",
+                "language, image, or embedding models",
             ));
         }
         Ok(self.model)
@@ -191,6 +223,16 @@ impl ModelBuilder {
             return Err(Error::unsupported_capability(
                 self.model.provider,
                 "image models",
+            ));
+        }
+        Ok(self.model)
+    }
+
+    pub fn build_embedding(self) -> Result<Model> {
+        if self.model.embedding_api.is_none() {
+            return Err(Error::unsupported_capability(
+                self.model.provider,
+                "embedding models",
             ));
         }
         Ok(self.model)

--- a/crates/ai/src/providers/anthropic.rs
+++ b/crates/ai/src/providers/anthropic.rs
@@ -75,6 +75,7 @@ impl Provider for Anthropic {
         ProviderCapabilities {
             language_models: true,
             image_models: false,
+            embedding_models: false,
         }
     }
 

--- a/crates/ai/src/providers/github_copilot.rs
+++ b/crates/ai/src/providers/github_copilot.rs
@@ -5,7 +5,9 @@ use crate::event_stream::AssistantEventStream;
 use crate::oauth::{GitHubCopilotOAuthProvider, OAuthApiKey, OAuthCredentials};
 use crate::provider::{LanguageModelApi, ModelBuilder, Provider, ProviderCapabilities};
 use crate::providers::github_copilot_headers::copilot_static_headers;
-use crate::providers::{anthropic, openai_completions, openai_responses, simple_options};
+use crate::providers::{
+    anthropic, openai_completions, openai_embeddings, openai_responses, simple_options,
+};
 use crate::types::{
     Context, Model, ModelCompat, ModelInput, OpenAIResponsesCompat, SimpleStreamOptions,
     StreamOptions,
@@ -57,6 +59,22 @@ impl GitHubCopilot {
     pub fn model(&self, id: &str) -> ModelBuilder {
         <Self as Provider>::model(self, id)
     }
+
+    pub fn embedding_model(&self, id: &str) -> ModelBuilder {
+        let runtime = Arc::new(openai_embeddings::OpenAiEmbeddingModelApi::new(
+            self.api_key.clone(),
+            false,
+            self.http_client.clone(),
+        ));
+        ModelBuilder::new_embedding(&self.provider_id, id, runtime)
+            .base_url(
+                self.base_url
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_BASE_URL.to_string()),
+            )
+            .headers(copilot_static_headers())
+            .input(vec![ModelInput::Text])
+    }
 }
 
 impl Provider for GitHubCopilot {
@@ -68,6 +86,7 @@ impl Provider for GitHubCopilot {
         ProviderCapabilities {
             language_models: true,
             image_models: false,
+            embedding_models: true,
         }
     }
 
@@ -341,5 +360,22 @@ mod tests {
         assert_eq!(model.id(), "future-model");
         assert_eq!(model.api_id(), "openai-completions");
         assert_eq!(model.base_url, "https://copilot.example");
+    }
+
+    #[test]
+    fn embedding_model_uses_openai_embeddings_api() {
+        let provider = builder()
+            .api_key("test-token")
+            .base_url("https://copilot.example")
+            .build()
+            .expect("provider");
+        let model = provider
+            .embedding_model("text-embedding-3-small")
+            .build_embedding()
+            .expect("model");
+
+        assert_eq!(model.api_id(), "openai-embeddings");
+        assert_eq!(model.base_url, "https://copilot.example");
+        assert_eq!(model.input, vec![ModelInput::Text]);
     }
 }

--- a/crates/ai/src/providers/mod.rs
+++ b/crates/ai/src/providers/mod.rs
@@ -6,6 +6,7 @@ pub mod github_copilot;
 pub(crate) mod github_copilot_headers;
 pub mod openai;
 pub mod openai_completions;
+pub(crate) mod openai_embeddings;
 pub(crate) mod openai_images;
 pub(crate) mod openai_prompt_cache;
 pub mod openai_responses;

--- a/crates/ai/src/providers/openai.rs
+++ b/crates/ai/src/providers/openai.rs
@@ -7,7 +7,9 @@ use crate::event_stream::AssistantEventStream;
 use crate::provider::{
     ImageModelApi, LanguageModelApi, ModelBuilder, Provider, ProviderCapabilities,
 };
-use crate::providers::{openai_completions, openai_images, openai_responses, simple_options};
+use crate::providers::{
+    openai_completions, openai_embeddings, openai_images, openai_responses, simple_options,
+};
 use crate::types::{
     AssistantImages, Context, ImageGenerationOptions, ImagesContext, Model, ModelCompat,
     ModelInput, ModelOutput, OpenAIResponsesCompat, SimpleStreamOptions, StreamOptions,
@@ -31,6 +33,7 @@ pub enum OpenAiApi {
     #[default]
     Responses,
     ChatCompletions,
+    Embeddings,
     Images,
 }
 
@@ -39,6 +42,7 @@ impl OpenAiApi {
         match self {
             Self::Responses => "openai-responses",
             Self::ChatCompletions => "openai-completions",
+            Self::Embeddings => "openai-embeddings",
             Self::Images => "openai-images",
         }
     }
@@ -63,6 +67,21 @@ impl OpenAi {
         self.image_model_builder(id)
     }
 
+    pub fn embedding_model(&self, id: &str) -> ModelBuilder {
+        self.embedding_model_builder(id)
+    }
+
+    fn embedding_model_builder(&self, id: &str) -> ModelBuilder {
+        let runtime = Arc::new(openai_embeddings::OpenAiEmbeddingModelApi::new(
+            self.api_key.clone(),
+            self.api_key.is_none() && self.base_url != DEFAULT_BASE_URL,
+            self.http_client.clone(),
+        ));
+        ModelBuilder::new_embedding(&self.provider_id, id, runtime)
+            .base_url(self.base_url.clone())
+            .input(vec![ModelInput::Text])
+    }
+
     fn image_model_builder(&self, id: &str) -> ModelBuilder {
         let runtime = Arc::new(OpenAiImageModelApi {
             api_key: self.api_key.clone(),
@@ -83,14 +102,18 @@ impl Provider for OpenAi {
 
     fn capabilities(&self) -> ProviderCapabilities {
         ProviderCapabilities {
-            language_models: self.api != OpenAiApi::Images,
+            language_models: !matches!(self.api, OpenAiApi::Embeddings | OpenAiApi::Images),
             image_models: true,
+            embedding_models: true,
         }
     }
 
     fn model(&self, id: &str) -> ModelBuilder {
         if self.api == OpenAiApi::Images {
             return self.image_model_builder(id);
+        }
+        if self.api == OpenAiApi::Embeddings {
+            return self.embedding_model_builder(id);
         }
 
         let runtime = Arc::new(OpenAiLanguageModelApi {
@@ -184,6 +207,11 @@ impl OpenAiBuilder {
 
     pub fn images(mut self) -> Self {
         self.api = OpenAiApi::Images;
+        self
+    }
+
+    pub fn embeddings(mut self) -> Self {
+        self.api = OpenAiApi::Embeddings;
         self
     }
 
@@ -307,7 +335,7 @@ impl LanguageModelApi for OpenAiLanguageModelApi {
                 context,
                 simple_options::openai_responses_options_from_stream_options(options),
             )),
-            OpenAiApi::Images => Err(Error::unsupported_capability(
+            OpenAiApi::Embeddings | OpenAiApi::Images => Err(Error::unsupported_capability(
                 model.provider,
                 "language models",
             )),
@@ -328,7 +356,7 @@ impl LanguageModelApi for OpenAiLanguageModelApi {
             OpenAiApi::Responses => {
                 openai_responses::stream_simple_openai_responses(model, context, options)
             }
-            OpenAiApi::Images => Err(Error::unsupported_capability(
+            OpenAiApi::Embeddings | OpenAiApi::Images => Err(Error::unsupported_capability(
                 model.provider,
                 "language models",
             )),

--- a/crates/ai/src/providers/openai_embeddings.rs
+++ b/crates/ai/src/providers/openai_embeddings.rs
@@ -1,0 +1,399 @@
+use async_trait::async_trait;
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+
+use crate::provider::EmbeddingModelApi;
+use crate::types::{
+    EmbeddingBatch, EmbeddingOptions, EmbeddingUsage, EmbeddingVector, KnownApi, Model,
+    ProviderResponse,
+};
+use crate::utils::headers::headers_to_record;
+use crate::utils::http::{request_timeout, send_request_with_retries};
+use crate::{Error, Result};
+
+#[derive(Clone)]
+pub(crate) struct OpenAiEmbeddingModelApi {
+    api_key: Option<String>,
+    allow_missing_api_key: bool,
+    http_client: Option<reqwest::Client>,
+}
+
+impl OpenAiEmbeddingModelApi {
+    pub(crate) fn new(
+        api_key: Option<String>,
+        allow_missing_api_key: bool,
+        http_client: Option<reqwest::Client>,
+    ) -> Self {
+        Self {
+            api_key,
+            allow_missing_api_key,
+            http_client,
+        }
+    }
+
+    fn with_runtime_options(&self, mut options: EmbeddingOptions) -> EmbeddingOptions {
+        if options
+            .base
+            .api_key
+            .as_deref()
+            .is_none_or(|api_key| api_key.trim().is_empty())
+            && let Some(api_key) = &self.api_key
+        {
+            options.base.api_key = Some(api_key.clone());
+        }
+        if options.base.http_client.is_none() {
+            options.base.http_client = self.http_client.clone();
+        }
+        options
+    }
+}
+
+#[async_trait]
+impl EmbeddingModelApi for OpenAiEmbeddingModelApi {
+    fn id(&self) -> &str {
+        KnownApi::OpenaiEmbeddings.as_str()
+    }
+
+    async fn embed_many(
+        &self,
+        model: Model,
+        inputs: Vec<String>,
+        options: EmbeddingOptions,
+    ) -> Result<EmbeddingBatch> {
+        embed_many_openai(
+            model,
+            inputs,
+            self.with_runtime_options(options),
+            self.allow_missing_api_key,
+        )
+        .await
+    }
+}
+
+pub(crate) async fn embed_many_openai(
+    model: Model,
+    inputs: Vec<String>,
+    options: EmbeddingOptions,
+    allow_missing_api_key: bool,
+) -> Result<EmbeddingBatch> {
+    if model.api != KnownApi::OpenaiEmbeddings.as_str() {
+        return Err(Error::UnsupportedApi(format!(
+            "Mismatched api: {} expected {}",
+            model.api,
+            KnownApi::OpenaiEmbeddings.as_str()
+        )));
+    }
+    let api_key = options
+        .base
+        .api_key
+        .as_deref()
+        .filter(|api_key| !api_key.trim().is_empty());
+    if api_key.is_none() && !allow_missing_api_key {
+        return Err(Error::MissingApiKey(model.provider.clone()));
+    }
+    let expected_count = inputs.len();
+    let mut payload = build_payload(&model, inputs, &options);
+    if let Some(on_payload) = &options.base.on_payload
+        && let Some(next_payload) = on_payload(Value::Object(payload.clone()), &model).await?
+    {
+        payload = next_payload.as_object().cloned().ok_or_else(|| {
+            Error::Provider("OpenAI embeddings payload hook must return a JSON object".to_string())
+        })?;
+    }
+
+    let client = options.base.http_client.clone().unwrap_or_default();
+    let url = format!("{}/embeddings", model.base_url.trim_end_matches('/'));
+    let headers = build_headers(api_key, &model.headers, &options.base.headers)?;
+    let response = send_request_with_retries(&options.base, || {
+        client
+            .post(&url)
+            .headers(headers.clone())
+            .json(&payload)
+            .timeout(request_timeout(options.base.timeout_ms))
+    })
+    .await?;
+    let status = response.status();
+    let response_headers = response.headers().clone();
+    let body = response.text().await?;
+    if !status.is_success() {
+        return Err(Error::ApiStatus { status, body });
+    }
+    if let Some(on_response) = &options.base.on_response {
+        on_response(
+            ProviderResponse {
+                status: status.as_u16(),
+                headers: headers_to_record(&response_headers),
+            },
+            &model,
+        )
+        .await?;
+    }
+
+    let response: OpenAiEmbeddingResponse = serde_json::from_str(&body).map_err(|error| {
+        Error::InvalidProviderResponse(format!("could not decode embeddings response: {error}"))
+    })?;
+    let mut data = response.data;
+    data.sort_by_key(|item| item.index);
+    if data.len() != expected_count
+        || data
+            .iter()
+            .enumerate()
+            .any(|(expected_index, item)| item.index != expected_index)
+    {
+        return Err(Error::InvalidProviderResponse(format!(
+            "expected {expected_count} indexed embeddings, received indices {:?}",
+            data.iter().map(|item| item.index).collect::<Vec<_>>()
+        )));
+    }
+    Ok(EmbeddingBatch {
+        embeddings: data.into_iter().map(|item| item.embedding).collect(),
+        model: response.model.unwrap_or(model.id),
+        usage: response.usage.unwrap_or_default(),
+    })
+}
+
+fn build_payload(
+    model: &Model,
+    inputs: Vec<String>,
+    options: &EmbeddingOptions,
+) -> Map<String, Value> {
+    let mut payload = Map::new();
+    payload.insert("model".to_string(), json!(model.id));
+    payload.insert("input".to_string(), json!(inputs));
+    if let Some(dimensions) = options.dimensions {
+        payload.insert("dimensions".to_string(), json!(dimensions));
+    }
+    if let Some(encoding_format) = options.encoding_format {
+        payload.insert(
+            "encoding_format".to_string(),
+            json!(encoding_format.as_str()),
+        );
+    }
+    if let Some(user) = &options.user {
+        payload.insert("user".to_string(), json!(user));
+    }
+    payload
+}
+
+fn build_headers(
+    api_key: Option<&str>,
+    model_headers: &std::collections::HashMap<String, String>,
+    option_headers: &crate::types::ProviderHeaders,
+) -> Result<HeaderMap> {
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    if let Some(api_key) = api_key {
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {api_key}"))
+                .map_err(|error| Error::InvalidHeaderValue("authorization".to_string(), error))?,
+        );
+    }
+    for (name, value) in model_headers {
+        let name = name
+            .parse::<HeaderName>()
+            .map_err(|error| Error::Provider(format!("invalid header name: {error}")))?;
+        let value = HeaderValue::from_str(value)
+            .map_err(|error| Error::InvalidHeaderValue(name.as_str().to_string(), error))?;
+        headers.insert(name, value);
+    }
+    crate::utils::headers::apply_provider_headers(&mut headers, option_headers)?;
+    Ok(headers)
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiEmbeddingResponse {
+    data: Vec<OpenAiEmbeddingData>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    usage: Option<EmbeddingUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiEmbeddingData {
+    embedding: EmbeddingVector,
+    index: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use serde_json::Value;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use crate::providers::openai;
+    use crate::types::{EmbeddingEncodingFormat, EmbeddingVector};
+
+    use super::*;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn single_embedding_uses_one_item_upstream_array() {
+        let captured = Arc::new(Mutex::new(String::new()));
+        let url = spawn_response_server(
+            Arc::clone(&captured),
+            r#"{"data":[{"embedding":[0.25,0.5],"index":0}],"usage":{"prompt_tokens":2,"total_tokens":2}}"#,
+        )
+        .await;
+        let provider = openai::builder()
+            .api_key(Some("test-key"))
+            .base_url(url)
+            .build()
+            .expect("provider");
+        let model = provider
+            .embedding_model("text-embedding-3-small")
+            .build_embedding()
+            .expect("model");
+
+        let output = crate::embed(model, "hello", None).await.expect("embedding");
+
+        assert_eq!(output.embedding, EmbeddingVector::Float(vec![0.25, 0.5]));
+        assert_eq!(output.model, "text-embedding-3-small");
+        let request = captured.lock().expect("request").clone();
+        assert!(request.starts_with("POST /v1/embeddings HTTP/1.1"));
+        assert_eq!(request_body_json(&request)["input"], json!(["hello"]));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn batch_embedding_preserves_index_order_and_options() {
+        let captured = Arc::new(Mutex::new(String::new()));
+        let url = spawn_response_server(
+            Arc::clone(&captured),
+            r#"{"data":[{"embedding":[3.0],"index":1},{"embedding":[1.0],"index":0}],"model":"upstream-model","usage":{"prompt_tokens":4,"total_tokens":4}}"#,
+        )
+        .await;
+        let provider = openai::builder()
+            .api_key(Some("test-key"))
+            .base_url(url)
+            .build()
+            .expect("provider");
+        let model = provider
+            .embedding_model("text-embedding-3-small")
+            .build_embedding()
+            .expect("model");
+        let options = EmbeddingOptions {
+            dimensions: Some(256),
+            encoding_format: Some(EmbeddingEncodingFormat::Float),
+            user: Some("test-user".to_string()),
+            ..Default::default()
+        };
+
+        let output = crate::embed_many(model, ["first", "second"], Some(options))
+            .await
+            .expect("embeddings");
+
+        assert_eq!(
+            output.embeddings,
+            vec![
+                EmbeddingVector::Float(vec![1.0]),
+                EmbeddingVector::Float(vec![3.0])
+            ]
+        );
+        assert_eq!(output.model, "upstream-model");
+        let payload = request_body_json(&captured.lock().expect("request").clone());
+        assert_eq!(payload["input"], json!(["first", "second"]));
+        assert_eq!(payload["dimensions"], 256);
+        assert_eq!(payload["encoding_format"], "float");
+        assert_eq!(payload["user"], "test-user");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn custom_endpoint_without_api_key_omits_authorization() {
+        let captured = Arc::new(Mutex::new(String::new()));
+        let url = spawn_response_server(
+            Arc::clone(&captured),
+            r#"{"data":[{"embedding":[0.25],"index":0}]}"#,
+        )
+        .await;
+        let provider = openai::builder().base_url(url).build().expect("provider");
+        let model = provider
+            .embedding_model("text-embedding-3-small")
+            .build_embedding()
+            .expect("model");
+
+        crate::embed(model, "hello", None).await.expect("embedding");
+
+        let request = captured.lock().expect("request").to_ascii_lowercase();
+        assert!(!request.contains("\r\nauthorization:"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rejects_missing_or_duplicate_response_indices() {
+        let captured = Arc::new(Mutex::new(String::new()));
+        let url = spawn_response_server(
+            captured,
+            r#"{"data":[{"embedding":[1.0],"index":0},{"embedding":[2.0],"index":0}]}"#,
+        )
+        .await;
+        let provider = openai::builder()
+            .api_key(Some("test-key"))
+            .base_url(url)
+            .build()
+            .expect("provider");
+        let model = provider
+            .embedding_model("text-embedding-3-small")
+            .build_embedding()
+            .expect("model");
+
+        let error = crate::embed_many(model, ["first", "second"], None)
+            .await
+            .expect_err("invalid indices should fail");
+
+        assert!(matches!(error, Error::InvalidProviderResponse(_)));
+    }
+
+    async fn spawn_response_server(captured: Arc<Mutex<String>>, body: &'static str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept");
+            let request = read_http_request(&mut socket).await;
+            *captured.lock().expect("captured request") = request;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        });
+        format!("http://{addr}/v1")
+    }
+
+    async fn read_http_request(socket: &mut tokio::net::TcpStream) -> String {
+        let mut buffer = Vec::new();
+        let mut temp = [0; 1024];
+        loop {
+            let read = socket.read(&mut temp).await.expect("read request");
+            buffer.extend_from_slice(&temp[..read]);
+            if let Some(header_end) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
+                let headers = String::from_utf8_lossy(&buffer[..header_end]);
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().ok())
+                            .flatten()
+                    })
+                    .unwrap_or_default();
+                while buffer.len() < header_end + 4 + content_length {
+                    let read = socket.read(&mut temp).await.expect("read body");
+                    buffer.extend_from_slice(&temp[..read]);
+                }
+                break;
+            }
+        }
+        String::from_utf8(buffer).expect("utf8 request")
+    }
+
+    fn request_body_json(request: &str) -> Value {
+        serde_json::from_str(request.split_once("\r\n\r\n").expect("body").1).expect("json")
+    }
+}

--- a/crates/ai/src/providers/openrouter.rs
+++ b/crates/ai/src/providers/openrouter.rs
@@ -53,6 +53,7 @@ impl Provider for OpenRouter {
         ProviderCapabilities {
             language_models: false,
             image_models: true,
+            embedding_models: false,
         }
     }
 

--- a/crates/ai/src/types.rs
+++ b/crates/ai/src/types.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use tokio_util::sync::CancellationToken;
 
 use crate::Result;
-use crate::provider::LanguageModelApi;
+use crate::provider::{EmbeddingModelApi, LanguageModelApi};
 
 pub type Api = String;
 pub type ProviderId = String;
@@ -78,6 +78,7 @@ fn is_false(value: &bool) -> bool {
 #[serde(rename_all = "kebab-case")]
 pub enum KnownApi {
     OpenaiCompletions,
+    OpenaiEmbeddings,
     OpenaiResponses,
     OpenaiImages,
     AnthropicMessages,
@@ -88,6 +89,7 @@ impl KnownApi {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::OpenaiCompletions => "openai-completions",
+            Self::OpenaiEmbeddings => "openai-embeddings",
             Self::OpenaiResponses => "openai-responses",
             Self::OpenaiImages => "openai-images",
             Self::AnthropicMessages => "anthropic-messages",
@@ -253,8 +255,78 @@ pub struct StreamOptions {
 }
 
 #[derive(Clone, Default)]
+pub struct RequestOptions {
+    pub cancellation_token: Option<CancellationToken>,
+    pub api_key: Option<String>,
+    pub on_payload: Option<PayloadHook>,
+    pub on_response: Option<ResponseHook>,
+    pub headers: ProviderHeaders,
+    pub timeout_ms: Option<u64>,
+    /// Maximum retry attempts for providers that support client-side retries.
+    pub max_retries: Option<u32>,
+    /// Maximum delay in milliseconds to wait when the server requests a long
+    /// retry delay. If the requested delay exceeds this value, the request
+    /// fails immediately. Defaults to 60 seconds; set to zero to disable the
+    /// cap.
+    pub max_retry_delay_ms: Option<u64>,
+    pub http_client: Option<reqwest::Client>,
+}
+
+#[derive(Clone, Default)]
 pub struct ImageGenerationOptions {
     pub base: StreamOptions,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EmbeddingEncodingFormat {
+    #[default]
+    Float,
+    Base64,
+}
+
+impl EmbeddingEncodingFormat {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Float => "float",
+            Self::Base64 => "base64",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct EmbeddingOptions {
+    pub base: RequestOptions,
+    pub dimensions: Option<u32>,
+    pub encoding_format: Option<EmbeddingEncodingFormat>,
+    pub user: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum EmbeddingVector {
+    Float(Vec<f32>),
+    Base64(String),
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmbeddingUsage {
+    pub prompt_tokens: u32,
+    pub total_tokens: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Embedding {
+    pub embedding: EmbeddingVector,
+    pub model: String,
+    pub usage: EmbeddingUsage,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EmbeddingBatch {
+    pub embeddings: Vec<EmbeddingVector>,
+    pub model: String,
+    pub usage: EmbeddingUsage,
 }
 
 #[derive(Clone, Default)]
@@ -1160,6 +1232,8 @@ pub struct Model {
     pub(crate) language_api: Option<Arc<dyn LanguageModelApi>>,
     #[serde(skip)]
     pub(crate) image_api: Option<Arc<dyn crate::provider::ImageModelApi>>,
+    #[serde(skip)]
+    pub(crate) embedding_api: Option<Arc<dyn EmbeddingModelApi>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1236,6 +1310,10 @@ impl Model {
 
     pub fn image_api(&self) -> Option<Arc<dyn crate::provider::ImageModelApi>> {
         self.image_api.clone()
+    }
+
+    pub fn embedding_api(&self) -> Option<Arc<dyn EmbeddingModelApi>> {
+        self.embedding_api.clone()
     }
 }
 

--- a/crates/ai/src/utils/http.rs
+++ b/crates/ai/src/utils/http.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use reqwest::{RequestBuilder, Response, StatusCode, header::HeaderMap};
 use ring::rand::{SecureRandom, SystemRandom};
 
-use crate::types::StreamOptions;
+use crate::types::{RequestOptions, StreamOptions};
 use crate::{Error, Result};
 
 pub const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 600_000;
@@ -17,20 +17,50 @@ pub async fn send_with_retries<F>(options: &StreamOptions, mut build: F) -> Resu
 where
     F: FnMut() -> RequestBuilder,
 {
-    let max_retries = options.max_retries.unwrap_or(0);
+    send_with_retry_config(
+        options.cancellation_token.as_ref(),
+        options.max_retries,
+        options.max_retry_delay_ms,
+        &mut build,
+    )
+    .await
+}
+
+pub async fn send_request_with_retries<F>(
+    options: &RequestOptions,
+    mut build: F,
+) -> Result<Response>
+where
+    F: FnMut() -> RequestBuilder,
+{
+    send_with_retry_config(
+        options.cancellation_token.as_ref(),
+        options.max_retries,
+        options.max_retry_delay_ms,
+        &mut build,
+    )
+    .await
+}
+
+async fn send_with_retry_config<F>(
+    cancellation_token: Option<&tokio_util::sync::CancellationToken>,
+    max_retries: Option<u32>,
+    max_retry_delay_ms: Option<u64>,
+    build: &mut F,
+) -> Result<Response>
+where
+    F: FnMut() -> RequestBuilder,
+{
+    let max_retries = max_retries.unwrap_or(0);
     let mut attempt = 0;
 
     loop {
-        if options
-            .cancellation_token
-            .as_ref()
-            .is_some_and(tokio_util::sync::CancellationToken::is_cancelled)
-        {
+        if cancellation_token.is_some_and(tokio_util::sync::CancellationToken::is_cancelled) {
             return Err(Error::Cancelled);
         }
 
         let send = build().send();
-        let result = if let Some(cancellation_token) = options.cancellation_token.as_ref() {
+        let result = if let Some(cancellation_token) = cancellation_token {
             tokio::select! {
                 _ = cancellation_token.cancelled() => Err(Error::Cancelled),
                 response = send => response.map_err(Error::from),
@@ -41,18 +71,13 @@ where
 
         match result {
             Ok(response) if attempt < max_retries && is_retryable_response(&response) => {
-                let delay_ms = match retry_delay_ms(
-                    response.headers(),
-                    attempt,
-                    options.max_retry_delay_ms,
-                ) {
+                let delay_ms = match retry_delay_ms(response.headers(), attempt, max_retry_delay_ms)
+                {
                     Ok(delay_ms) => delay_ms,
                     Err(Error::Provider(message)) => {
                         let status = response.status();
                         let read_body = response.text();
-                        let body = if let Some(cancellation_token) =
-                            options.cancellation_token.as_ref()
-                        {
+                        let body = if let Some(cancellation_token) = cancellation_token {
                             tokio::select! {
                                 _ = cancellation_token.cancelled() => return Err(Error::Cancelled),
                                 body = read_body => body.unwrap_or_default(),
@@ -67,20 +92,42 @@ where
                     }
                     Err(error) => return Err(error),
                 };
-                sleep_before_retry(options, delay_ms).await?;
+                sleep_before_retry_token(cancellation_token, delay_ms).await?;
                 attempt += 1;
             }
             Ok(response) => return Ok(response),
             Err(Error::Cancelled) => return Err(Error::Cancelled),
-            Err(error) if attempt < max_retries => {
-                let delay_ms =
-                    retry_delay_ms(&HeaderMap::new(), attempt, options.max_retry_delay_ms)?;
-                sleep_before_retry(options, delay_ms).await?;
+            Err(_) if attempt < max_retries => {
+                let delay_ms = retry_delay_ms(&HeaderMap::new(), attempt, max_retry_delay_ms)?;
+                sleep_before_retry_token(cancellation_token, delay_ms).await?;
                 attempt += 1;
-                let _ = error;
             }
             Err(error) => return Err(error),
         }
+    }
+}
+
+async fn sleep_before_retry_token(
+    cancellation_token: Option<&tokio_util::sync::CancellationToken>,
+    delay_ms: f64,
+) -> Result<()> {
+    if delay_ms.is_nan() || delay_ms <= 0.0 {
+        return Ok(());
+    }
+    let delay = if delay_ms.is_finite() {
+        Duration::from_secs_f64(delay_ms / 1000.0)
+    } else {
+        Duration::MAX
+    };
+
+    if let Some(cancellation_token) = cancellation_token {
+        tokio::select! {
+            _ = cancellation_token.cancelled() => Err(Error::Cancelled),
+            _ = tokio::time::sleep(delay) => Ok(()),
+        }
+    } else {
+        tokio::time::sleep(delay).await;
+        Ok(())
     }
 }
 
@@ -106,27 +153,6 @@ fn is_retryable_status(status: StatusCode) -> bool {
         status,
         StatusCode::REQUEST_TIMEOUT | StatusCode::CONFLICT | StatusCode::TOO_MANY_REQUESTS
     ) || status.is_server_error()
-}
-
-async fn sleep_before_retry(options: &StreamOptions, delay_ms: f64) -> Result<()> {
-    if delay_ms.is_nan() || delay_ms <= 0.0 {
-        return Ok(());
-    }
-    let delay = if delay_ms.is_finite() {
-        Duration::from_secs_f64(delay_ms / 1000.0)
-    } else {
-        Duration::MAX
-    };
-
-    if let Some(cancellation_token) = options.cancellation_token.as_ref() {
-        tokio::select! {
-            _ = cancellation_token.cancelled() => Err(Error::Cancelled),
-            _ = tokio::time::sleep(delay) => Ok(()),
-        }
-    } else {
-        tokio::time::sleep(delay).await;
-        Ok(())
-    }
 }
 
 fn retry_delay_ms(


### PR DESCRIPTION
## Summary

- add `embed` and `embed_many` APIs
- add OpenAI-compatible embedding transport with float and base64 output support
- add OpenAI and GitHub Copilot embedding model builders
- validate batch inputs and provider response indices
- support compatible endpoints without requiring an Authorization header
- document embedding usage and compatibility behavior

## Verification

- `env -u CC -u CXX cargo test -p ai` (525 passed)
- `env -u CC -u CXX cargo check -p ai --all-targets`
- `env -u CC -u CXX cargo clippy -p ai --all-targets -- -D warnings`
- `env -u CC -u CXX cargo fmt --all -- --check`
- live single and three-input batch requests against GitHub Copilot `text-embedding-3-small`