### PR TITLE
test: cover placeholder function-call arguments

### DIFF
--- a/crates/ai/src/providers/openai_responses.rs
+++ b/crates/ai/src/providers/openai_responses.rs
@@ -4881,7 +4881,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn response_function_call_done_replaces_delta_arguments() {
+    async fn response_function_call_done_uses_final_arguments_after_placeholder_start() {
         let body = sse_body(&[
             json!({
                 "type": "response.output_item.added",
@@ -4891,7 +4891,7 @@ mod tests {
                     "id": "fc_test",
                     "call_id": "call_test",
                     "name": "edit",
-                    "arguments": ""
+                    "arguments": "{}"
                 }
             }),
             json!({
@@ -4903,11 +4903,6 @@ mod tests {
                 "type": "response.function_call_arguments.delta",
                 "output_index": 0,
                 "delta": ",\"content\":\"updated\"}"
-            }),
-            json!({
-                "type": "response.function_call_arguments.done",
-                "output_index": 0,
-                "arguments": "{\"path\":\"README.md\",\"content\":\"updated\"}"
             }),
             json!({
                 "type": "response.output_item.done",


### PR DESCRIPTION
## Summary

- cover streamed function calls that begin with placeholder `{}` arguments
- verify final `response.output_item.done` arguments win when no separate arguments-done event is emitted
- match the event sequence produced by OpenAI-compatible Responses proxies

## Verification

- RED on `2433403`: focused regression failed with empty tool arguments
- GREEN on current `main`: focused regression passed
- `cargo test -p ai` (525 passed)
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
