### PR TITLE
fix(copilot): route each model to the API it supports

### DIFF
--- a/crates/ai/src/oauth/github_copilot.rs
+++ b/crates/ai/src/oauth/github_copilot.rs
@@ -367,8 +367,13 @@ pub async fn login_github_copilot(callbacks: OAuthLoginCallbacks) -> Result<OAut
     let token = mint_copilot_token(&github.access_token, enterprise_domain.as_deref()).await?;
 
     // Claude, Grok, and similar models stay hidden until their policy is
-    // accepted, so enable them once here the way pi does at login.
-    enable_all_github_copilot_models(&token.token, enterprise_domain.as_deref()).await;
+    // accepted, so enable them once here before listing what is available.
+    enable_all_github_copilot_models(
+        &token.token,
+        enterprise_domain.as_deref(),
+        callbacks.cancellation_token.clone(),
+    )
+    .await;
 
     let mut credentials = copilot_credentials_from_token(
         &github.access_token,
@@ -478,14 +483,17 @@ async fn send_copilot_models_request(
         .await?)
 }
 
-/// Enables the Copilot models that require explicit policy acceptance, such as
-/// Claude and Grok. Mirrors pi's `enableAllGitHubCopilotModels`, which runs once
-/// at login so the account's picker exposes every entitled model.
+/// Accepts the policy on every Copilot model that still requires it, such as
+/// Claude and Grok, so the account's picker exposes each entitled model.
 ///
-/// pi walks its generated Copilot catalog; ai.rs has no such catalog, so the
-/// pending ids come from the `/models` response instead. Every step is
-/// best-effort: a login must not fail because a policy update was rejected.
-async fn enable_all_github_copilot_models(copilot_token: &str, enterprise_domain: Option<&str>) {
+/// Runs once at login. The pending ids come from the `/models` response, and
+/// every step is best-effort: a login must not fail because a policy update was
+/// rejected or the account is not entitled to a model.
+async fn enable_all_github_copilot_models(
+    copilot_token: &str,
+    enterprise_domain: Option<&str>,
+    cancellation_token: Option<CancellationToken>,
+) {
     let base_url = get_github_copilot_base_url(Some(copilot_token), enterprise_domain);
     let Ok(client) = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))
@@ -500,6 +508,12 @@ async fn enable_all_github_copilot_models(copilot_token: &str, enterprise_domain
         return;
     };
     for id in policy_pending_copilot_model_ids(&raw) {
+        if cancellation_token
+            .as_ref()
+            .is_some_and(CancellationToken::is_cancelled)
+        {
+            return;
+        }
         enable_github_copilot_model(&client, &base_url, copilot_token, &id).await;
     }
 }
@@ -526,14 +540,15 @@ fn policy_pending_copilot_model_ids(raw: &Value) -> Vec<String> {
         .collect()
 }
 
+/// Accepts the policy for a single model, reporting whether Copilot agreed.
 async fn enable_github_copilot_model(
     client: &reqwest::Client,
     base_url: &str,
     copilot_token: &str,
     model_id: &str,
-) {
+) -> bool {
     let Ok(mut headers) = copilot_headers(Some(copilot_token)) else {
-        return;
+        return false;
     };
     headers.insert(
         reqwest::header::CONTENT_TYPE,
@@ -547,12 +562,13 @@ async fn enable_github_copilot_model(
         "x-interaction-type",
         reqwest::header::HeaderValue::from_static("chat-policy"),
     );
-    let _ = client
+    client
         .post(format!("{base_url}/models/{model_id}/policy"))
         .headers(headers)
         .json(&serde_json::json!({ "state": "enabled" }))
         .send()
-        .await;
+        .await
+        .is_ok_and(|response| response.status().is_success())
 }
 
 fn parse_available_copilot_model_ids(
@@ -1428,6 +1444,48 @@ mod tests {
         assert!(
             body.contains(&format!("client_id={GITHUB_COPILOT_CLIENT_ID}")),
             "body: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn enabling_a_model_policy_reports_whether_copilot_accepted_it() {
+        // The policy update is best-effort, but callers still need to know
+        // whether it landed, so a rejection must not look like success.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let seen = captured.clone();
+        tokio::spawn(async move {
+            for status in ["200 OK", "403 Forbidden"] {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let request = read_http_request(&mut socket).await;
+                seen.lock().expect("lock poisoned").push(request);
+                let response = format!("HTTP/1.1 {status}\r\ncontent-length: 0\r\n\r\n");
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+
+        let base_url = format!("http://{addr}");
+        let client = reqwest::Client::new();
+        assert!(
+            enable_github_copilot_model(&client, &base_url, "tid=token", "claude-sonnet-5").await
+        );
+        assert!(
+            !enable_github_copilot_model(&client, &base_url, "tid=token", "claude-opus-4.8").await
+        );
+
+        let requests = captured.lock().expect("lock poisoned").clone();
+        assert!(
+            requests[0].starts_with("POST /models/claude-sonnet-5/policy"),
+            "request: {}",
+            requests[0]
+        );
+        assert!(
+            requests[0]
+                .to_ascii_lowercase()
+                .contains("openai-intent: chat-policy"),
+            "request: {}",
+            requests[0]
         );
     }
 

--- a/crates/ai/src/oauth/github_copilot.rs
+++ b/crates/ai/src/oauth/github_copilot.rs
@@ -29,6 +29,9 @@ const GITHUB_COPILOT_AVAILABLE_MODEL_IDS_KEY: &str = "availableModelIds";
 
 const GITHUB_ACCESS_TOKEN_EXPIRY_SKEW_MS: u64 = 5 * 60 * 1000;
 
+const COPILOT_MAX_RETRY_AFTER_MS: u64 = 10_000;
+const COPILOT_DEFAULT_RETRY_AFTER_MS: u64 = 1_000;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GitHubCopilotOAuthProvider;
 
@@ -363,6 +366,10 @@ pub async fn login_github_copilot(callbacks: OAuthLoginCallbacks) -> Result<OAut
     let github_expires = github.expires_in.map(github_access_expiry_ms);
     let token = mint_copilot_token(&github.access_token, enterprise_domain.as_deref()).await?;
 
+    // Claude, Grok, and similar models stay hidden until their policy is
+    // accepted, so enable them once here the way pi does at login.
+    enable_all_github_copilot_models(&token.token, enterprise_domain.as_deref()).await;
+
     let mut credentials = copilot_credentials_from_token(
         &github.access_token,
         github.refresh_token.as_deref(),
@@ -434,17 +441,124 @@ async fn fetch_available_copilot_model_ids_at(
     base_url: &str,
     copilot_token: &str,
 ) -> Result<Vec<String>> {
-    let response = client
+    // Login-time policy updates can drain the Copilot rate-limit bucket, so a
+    // 429 here is expected. Honor Retry-After once instead of failing login.
+    let mut response = send_copilot_models_request(client, base_url, copilot_token).await?;
+    if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        let wait = response
+            .headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|seconds| *seconds > 0)
+            .map_or(COPILOT_DEFAULT_RETRY_AFTER_MS, |seconds| {
+                (seconds * 1000).min(COPILOT_MAX_RETRY_AFTER_MS)
+            });
+        abortable_sleep(Duration::from_millis(wait), None).await?;
+        response = send_copilot_models_request(client, base_url, copilot_token).await?;
+    }
+    let response = error_for_status(response).await?;
+    // Some Individual accounts return false for every picker flag despite
+    // explicit enabled policies. Limit the fallback to that endpoint so other
+    // account types keep strict picker semantics.
+    let allow_policy_fallback = base_url == DEFAULT_COPILOT_BASE_URL;
+    parse_available_copilot_model_ids(response.json::<Value>().await?, allow_policy_fallback)
+}
+
+async fn send_copilot_models_request(
+    client: &reqwest::Client,
+    base_url: &str,
+    copilot_token: &str,
+) -> Result<reqwest::Response> {
+    Ok(client
         .get(format!("{base_url}/models"))
         .headers(copilot_headers(Some(copilot_token))?)
         .header("X-GitHub-Api-Version", COPILOT_API_VERSION)
         .send()
-        .await?;
-    let response = error_for_status(response).await?;
-    parse_available_copilot_model_ids(response.json::<Value>().await?)
+        .await?)
 }
 
-fn parse_available_copilot_model_ids(raw: Value) -> Result<Vec<String>> {
+/// Enables the Copilot models that require explicit policy acceptance, such as
+/// Claude and Grok. Mirrors pi's `enableAllGitHubCopilotModels`, which runs once
+/// at login so the account's picker exposes every entitled model.
+///
+/// pi walks its generated Copilot catalog; ai.rs has no such catalog, so the
+/// pending ids come from the `/models` response instead. Every step is
+/// best-effort: a login must not fail because a policy update was rejected.
+async fn enable_all_github_copilot_models(copilot_token: &str, enterprise_domain: Option<&str>) {
+    let base_url = get_github_copilot_base_url(Some(copilot_token), enterprise_domain);
+    let Ok(client) = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+    else {
+        return;
+    };
+    let Ok(response) = send_copilot_models_request(&client, &base_url, copilot_token).await else {
+        return;
+    };
+    let Ok(raw) = response.json::<Value>().await else {
+        return;
+    };
+    for id in policy_pending_copilot_model_ids(&raw) {
+        enable_github_copilot_model(&client, &base_url, copilot_token, &id).await;
+    }
+}
+
+/// Model ids that declare a policy that is not yet enabled.
+fn policy_pending_copilot_model_ids(raw: &Value) -> Vec<String> {
+    let Some(data) = raw
+        .as_object()
+        .and_then(|object| object.get("data"))
+        .and_then(Value::as_array)
+    else {
+        return Vec::new();
+    };
+    data.iter()
+        .filter_map(Value::as_object)
+        .filter(|item| {
+            item.get("policy")
+                .and_then(Value::as_object)
+                .and_then(|policy| policy.get("state"))
+                .and_then(Value::as_str)
+                .is_some_and(|state| state != "enabled")
+        })
+        .filter_map(|item| item.get("id").and_then(Value::as_str).map(str::to_string))
+        .collect()
+}
+
+async fn enable_github_copilot_model(
+    client: &reqwest::Client,
+    base_url: &str,
+    copilot_token: &str,
+    model_id: &str,
+) {
+    let Ok(mut headers) = copilot_headers(Some(copilot_token)) else {
+        return;
+    };
+    headers.insert(
+        reqwest::header::CONTENT_TYPE,
+        reqwest::header::HeaderValue::from_static("application/json"),
+    );
+    headers.insert(
+        "openai-intent",
+        reqwest::header::HeaderValue::from_static("chat-policy"),
+    );
+    headers.insert(
+        "x-interaction-type",
+        reqwest::header::HeaderValue::from_static("chat-policy"),
+    );
+    let _ = client
+        .post(format!("{base_url}/models/{model_id}/policy"))
+        .headers(headers)
+        .json(&serde_json::json!({ "state": "enabled" }))
+        .send()
+        .await;
+}
+
+fn parse_available_copilot_model_ids(
+    raw: Value,
+    allow_policy_fallback: bool,
+) -> Result<Vec<String>> {
     let Some(data) = raw
         .as_object()
         .and_then(|object| object.get("data"))
@@ -455,28 +569,44 @@ fn parse_available_copilot_model_ids(raw: Value) -> Result<Vec<String>> {
         ));
     };
 
-    Ok(data
-        .iter()
-        .filter_map(Value::as_object)
-        .filter(|item| item.get("model_picker_enabled").and_then(Value::as_bool) == Some(true))
-        .filter(|item| {
-            item.get("policy")
-                .and_then(Value::as_object)
-                .and_then(|policy| policy.get("state"))
-                .and_then(Value::as_str)
-                != Some("disabled")
-        })
-        .filter(|item| {
-            item.get("capabilities")
-                .and_then(Value::as_object)
-                .and_then(|capabilities| capabilities.get("supports"))
-                .and_then(Value::as_object)
-                .and_then(|supports| supports.get("tool_calls"))
-                .and_then(Value::as_bool)
-                != Some(false)
-        })
-        .filter_map(|item| item.get("id").and_then(Value::as_str).map(str::to_string))
-        .collect())
+    let mut picker_ids = Vec::new();
+    let mut policy_enabled_ids = Vec::new();
+    for item in data.iter().filter_map(Value::as_object) {
+        let Some(id) = item.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        let supports_tool_calls = item
+            .get("capabilities")
+            .and_then(Value::as_object)
+            .and_then(|capabilities| capabilities.get("supports"))
+            .and_then(Value::as_object)
+            .and_then(|supports| supports.get("tool_calls"))
+            .and_then(Value::as_bool)
+            != Some(false);
+        if !supports_tool_calls {
+            continue;
+        }
+        let policy_state = item
+            .get("policy")
+            .and_then(Value::as_object)
+            .and_then(|policy| policy.get("state"))
+            .and_then(Value::as_str);
+        if item.get("model_picker_enabled").and_then(Value::as_bool) == Some(true)
+            && policy_state != Some("disabled")
+        {
+            picker_ids.push(id.to_string());
+        }
+        if policy_state == Some("enabled") {
+            policy_enabled_ids.push(id.to_string());
+        }
+    }
+
+    // Some Individual accounts report false for every picker flag even though
+    // policies are explicitly enabled, which would otherwise hide every model.
+    if picker_ids.is_empty() && allow_policy_fallback {
+        return Ok(policy_enabled_ids);
+    }
+    Ok(picker_ids)
 }
 
 async fn start_github_device_flow(domain: &str) -> Result<DeviceCodeResponse> {
@@ -903,39 +1033,90 @@ mod tests {
 
     #[test]
     fn parses_only_selectable_copilot_models() {
-        let ids = parse_available_copilot_model_ids(serde_json::json!({
-            "data": [
-                {
-                    "id": "gpt-4.1",
-                    "model_picker_enabled": true,
-                    "capabilities": { "supports": { "tool_calls": true } }
-                },
-                {
-                    "id": "claude-opus-4.7",
-                    "model_picker_enabled": true,
-                    "policy": { "state": "disabled" },
-                    "capabilities": { "supports": { "tool_calls": true } }
-                },
-                {
-                    "id": "gpt-5.4-nano",
-                    "model_picker_enabled": false,
-                    "capabilities": { "supports": { "tool_calls": true } }
-                },
-                {
-                    "id": "text-only",
-                    "model_picker_enabled": true,
-                    "capabilities": { "supports": { "tool_calls": false } }
-                }
-            ]
-        }))
+        let ids = parse_available_copilot_model_ids(
+            serde_json::json!({
+                "data": [
+                    {
+                        "id": "gpt-4.1",
+                        "model_picker_enabled": true,
+                        "capabilities": { "supports": { "tool_calls": true } }
+                    },
+                    {
+                        "id": "claude-opus-4.7",
+                        "model_picker_enabled": true,
+                        "policy": { "state": "disabled" },
+                        "capabilities": { "supports": { "tool_calls": true } }
+                    },
+                    {
+                        "id": "gpt-5.4-nano",
+                        "model_picker_enabled": false,
+                        "capabilities": { "supports": { "tool_calls": true } }
+                    },
+                    {
+                        "id": "text-only",
+                        "model_picker_enabled": true,
+                        "capabilities": { "supports": { "tool_calls": false } }
+                    }
+                ]
+            }),
+            false,
+        )
         .expect("models response");
 
         assert_eq!(ids, vec!["gpt-4.1"]);
         assert_eq!(
-            parse_available_copilot_model_ids(serde_json::json!({}))
+            parse_available_copilot_model_ids(serde_json::json!({}), false)
                 .unwrap_err()
                 .to_string(),
             "provider error: Invalid Copilot models response"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_policy_enabled_models_when_picker_is_empty() {
+        let raw = serde_json::json!({
+            "data": [
+                {
+                    "id": "claude-sonnet-5",
+                    "model_picker_enabled": false,
+                    "policy": { "state": "enabled" },
+                    "capabilities": { "supports": { "tool_calls": true } }
+                },
+                {
+                    "id": "unconfigured",
+                    "model_picker_enabled": false,
+                    "policy": { "state": "unconfigured" },
+                    "capabilities": { "supports": { "tool_calls": true } }
+                }
+            ]
+        });
+
+        assert_eq!(
+            parse_available_copilot_model_ids(raw.clone(), true).expect("models"),
+            vec!["claude-sonnet-5"]
+        );
+        assert!(
+            parse_available_copilot_model_ids(raw, false)
+                .expect("models")
+                .is_empty(),
+            "strict picker semantics apply when the fallback is not allowed"
+        );
+    }
+
+    #[test]
+    fn policy_pending_ids_skip_already_enabled_models() {
+        let raw = serde_json::json!({
+            "data": [
+                { "id": "enabled-model", "policy": { "state": "enabled" } },
+                { "id": "unconfigured-model", "policy": { "state": "unconfigured" } },
+                { "id": "disabled-model", "policy": { "state": "disabled" } },
+                { "id": "no-policy-model" }
+            ]
+        });
+
+        assert_eq!(
+            policy_pending_copilot_model_ids(&raw),
+            vec!["unconfigured-model", "disabled-model"]
         );
     }
 

--- a/crates/ai/src/providers/github_copilot.rs
+++ b/crates/ai/src/providers/github_copilot.rs
@@ -9,8 +9,8 @@ use crate::providers::{
     anthropic, openai_completions, openai_embeddings, openai_responses, simple_options,
 };
 use crate::types::{
-    Context, Model, ModelCompat, ModelInput, OpenAIResponsesCompat, SimpleStreamOptions,
-    StreamOptions,
+    Context, Model, ModelCompat, ModelInput, OpenAICompletionsCompat, OpenAIResponsesCompat,
+    SimpleStreamOptions, StreamOptions,
 };
 use crate::{Error, Result};
 
@@ -91,7 +91,7 @@ impl Provider for GitHubCopilot {
     }
 
     fn model(&self, id: &str) -> ModelBuilder {
-        let api = self.api.unwrap_or_default();
+        let api = self.api.unwrap_or_else(|| default_api_for_model(id));
         let runtime = Arc::new(GitHubCopilotLanguageModelApi {
             api,
             api_key: self.api_key.clone(),
@@ -101,12 +101,28 @@ impl Provider for GitHubCopilot {
             .base_url
             .clone()
             .unwrap_or_else(|| DEFAULT_BASE_URL.to_string());
+        let base_url = if api == GitHubCopilotApi::AnthropicMessages {
+            anthropic_messages_base_url(&base_url)
+        } else {
+            base_url
+        };
         let mut compat = ModelCompat::default();
-        if api == GitHubCopilotApi::OpenAiResponses {
-            compat.openai_responses = OpenAIResponsesCompat {
-                supports_openai_grammar_tools: is_gpt_5_or_newer(id).then_some(true),
-                ..Default::default()
-            };
+        match api {
+            GitHubCopilotApi::OpenAiResponses => {
+                compat.openai_responses = OpenAIResponsesCompat {
+                    supports_openai_grammar_tools: is_gpt_5_or_newer(id).then_some(true),
+                    ..Default::default()
+                };
+            }
+            GitHubCopilotApi::OpenAiChatCompletions => {
+                compat.openai_completions = OpenAICompletionsCompat {
+                    supports_store: Some(false),
+                    supports_developer_role: Some(false),
+                    supports_reasoning_effort: Some(false),
+                    ..Default::default()
+                };
+            }
+            GitHubCopilotApi::AnthropicMessages => {}
         }
         ModelBuilder::new(&self.provider_id, id, runtime)
             .base_url(base_url)
@@ -123,6 +139,56 @@ fn is_gpt_5_or_newer(id: &str) -> bool {
         .and_then(|suffix| suffix.split(['.', '-']).next())
         .and_then(|major| major.parse::<u32>().ok())
         .is_some_and(|major| major >= 5)
+}
+
+/// Copilot serves Claude 4.x and 5.x through the Anthropic Messages API, and
+/// Grok, GPT-5, `oswe`, and MAI models only through `/responses`. Everything
+/// else goes through Chat Completions. Mirrors the per-model `api` assignment
+/// pi bakes into its generated Copilot catalog.
+fn default_api_for_model(id: &str) -> GitHubCopilotApi {
+    if is_copilot_claude(id) {
+        GitHubCopilotApi::AnthropicMessages
+    } else if needs_responses_api(id) {
+        GitHubCopilotApi::OpenAiResponses
+    } else {
+        GitHubCopilotApi::OpenAiChatCompletions
+    }
+}
+
+/// Matches pi's `/^claude-(haiku|sonnet|opus)-[45]([.\-]|$)/`.
+fn is_copilot_claude(id: &str) -> bool {
+    let Some(rest) = id.strip_prefix("claude-") else {
+        return false;
+    };
+    let rest = ["haiku-", "sonnet-", "opus-"]
+        .iter()
+        .find_map(|family| rest.strip_prefix(family));
+    let Some(rest) = rest else {
+        return false;
+    };
+    let mut chars = rest.chars();
+    if !matches!(chars.next(), Some('4' | '5')) {
+        return false;
+    }
+    matches!(chars.next(), None | Some('.') | Some('-'))
+}
+
+fn needs_responses_api(id: &str) -> bool {
+    id.starts_with("grok-")
+        || id.starts_with("gpt-5")
+        || id.starts_with("oswe")
+        || id.starts_with("mai-")
+}
+
+/// Copilot exposes the Anthropic Messages API under `/v1/messages`, while
+/// [`anthropic`] appends `/messages` to the configured base URL. Add the
+/// version segment so Copilot Claude requests do not 404.
+fn anthropic_messages_base_url(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    if trimmed.ends_with("/v1") {
+        return trimmed.to_string();
+    }
+    format!("{trimmed}/v1")
 }
 
 #[derive(Default)]
@@ -311,6 +377,99 @@ mod tests {
     use super::*;
 
     #[test]
+    fn selects_the_api_pi_assigns_to_each_copilot_model() {
+        for id in [
+            "claude-sonnet-5",
+            "claude-opus-4.8",
+            "claude-haiku-4.5",
+            "claude-sonnet-4",
+        ] {
+            assert_eq!(
+                default_api_for_model(id),
+                GitHubCopilotApi::AnthropicMessages,
+                "{id} should use the Anthropic Messages API"
+            );
+        }
+        for id in [
+            "gpt-5.6-sol",
+            "grok-4.5",
+            "oswe-preview",
+            "mai-code-1-flash",
+        ] {
+            assert_eq!(
+                default_api_for_model(id),
+                GitHubCopilotApi::OpenAiResponses,
+                "{id} should use the Responses API"
+            );
+        }
+        for id in [
+            "gpt-4.1",
+            "gemini-3.7-flash",
+            "claude-sonnet-3.7",
+            "o3-mini",
+        ] {
+            assert_eq!(
+                default_api_for_model(id),
+                GitHubCopilotApi::OpenAiChatCompletions,
+                "{id} should use Chat Completions"
+            );
+        }
+    }
+
+    #[test]
+    fn claude_models_target_the_copilot_anthropic_version_path() {
+        let provider = builder()
+            .api_key("test-token")
+            .base_url("https://api.enterprise.githubcopilot.com")
+            .build()
+            .expect("provider");
+        let claude = provider.model("claude-sonnet-5").build().expect("model");
+        let gpt = provider.model("gpt-5.6-sol").build().expect("model");
+
+        assert_eq!(claude.api_id(), "anthropic-messages");
+        assert_eq!(
+            claude.base_url, "https://api.enterprise.githubcopilot.com/v1",
+            "Copilot serves Anthropic Messages under /v1/messages"
+        );
+        assert_eq!(gpt.api_id(), "openai-responses");
+        assert_eq!(gpt.base_url, "https://api.enterprise.githubcopilot.com");
+    }
+
+    #[test]
+    fn explicit_api_selection_still_wins() {
+        let provider = builder()
+            .api_key("test-token")
+            .base_url("https://api.enterprise.githubcopilot.com")
+            .chat_completions()
+            .build()
+            .expect("provider");
+        let claude = provider.model("claude-sonnet-5").build().expect("model");
+
+        assert_eq!(claude.api_id(), "openai-completions");
+        assert_eq!(claude.compat.openai_completions.supports_store, Some(false));
+        assert_eq!(
+            claude.compat.openai_completions.supports_developer_role,
+            Some(false)
+        );
+        assert_eq!(
+            claude.compat.openai_completions.supports_reasoning_effort,
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn anthropic_base_url_is_not_double_versioned() {
+        assert_eq!(
+            anthropic_messages_base_url("https://api.example.com/v1"),
+            "https://api.example.com/v1"
+        );
+        assert_eq!(
+            anthropic_messages_base_url("https://api.example.com/"),
+            "https://api.example.com/v1"
+        );
+    }
+
+    #[test]
     fn responses_gpt_5_models_enable_pi_grammar_tools() {
         let provider = builder().api_key("test-token").build().expect("provider");
         let gpt_5 = provider.model("gpt-5.4").build().expect("model");
@@ -327,13 +486,13 @@ mod tests {
     }
 
     #[test]
-    fn default_model_uses_responses_api_without_catalog_metadata() {
+    fn default_model_routing_applies_without_catalog_metadata() {
         let provider = builder().api_key("test-token").build().expect("provider");
         let model = provider.model("claude-opus-4.5").build().expect("model");
 
         assert_eq!(model.provider_id(), "github-copilot");
-        assert_eq!(model.api_id(), "openai-responses");
-        assert_eq!(model.base_url, DEFAULT_BASE_URL);
+        assert_eq!(model.api_id(), "anthropic-messages");
+        assert_eq!(model.base_url, format!("{DEFAULT_BASE_URL}/v1"));
         assert_eq!(
             model.headers.get("Editor-Version").map(String::as_str),
             Some("vscode/1.107.0")

--- a/crates/ai/src/providers/github_copilot.rs
+++ b/crates/ai/src/providers/github_copilot.rs
@@ -143,8 +143,8 @@ fn is_gpt_5_or_newer(id: &str) -> bool {
 
 /// Copilot serves Claude 4.x and 5.x through the Anthropic Messages API, and
 /// Grok, GPT-5, `oswe`, and MAI models only through `/responses`. Everything
-/// else goes through Chat Completions. Mirrors the per-model `api` assignment
-/// pi bakes into its generated Copilot catalog.
+/// else goes through Chat Completions. Used when the catalog carries no
+/// explicit `api` for a model.
 fn default_api_for_model(id: &str) -> GitHubCopilotApi {
     if is_copilot_claude(id) {
         GitHubCopilotApi::AnthropicMessages
@@ -155,7 +155,8 @@ fn default_api_for_model(id: &str) -> GitHubCopilotApi {
     }
 }
 
-/// Matches pi's `/^claude-(haiku|sonnet|opus)-[45]([.\-]|$)/`.
+/// Matches `claude-{haiku,sonnet,opus}-{4,5}` and its dotted or dashed
+/// revisions, the families Copilot serves over the Anthropic Messages API.
 fn is_copilot_claude(id: &str) -> bool {
     let Some(rest) = id.strip_prefix("claude-") else {
         return false;


### PR DESCRIPTION
## Summary

The GitHub Copilot provider sent every model to the Responses API, which left several models unusable. This fixes routing, the Anthropic path, and login-time model policies.

### 1. Every model was sent to the Responses API

`GitHubCopilotApi` defaulted to `OpenAiResponses` for *all* models when the catalog carried no explicit API. Copilot rejects Claude and Gemini there with `400 unsupported_api_for_model`, so those models returned an **empty response**.

The API is now inferred from the model id when the catalog does not specify one:

| Model pattern | API |
| --- | --- |
| `claude-{haiku,sonnet,opus}-{4,5}...` | `anthropic-messages` |
| `grok-*`, `gpt-5*`, `oswe*`, `mai-*` | `openai-responses` |
| everything else | `openai-completions` |

An explicit `api` from the catalog or the builder still wins; the rule only supplies the default.

Per-API compatibility flags follow: Responses keeps grammar-based tools, while Chat Completions marks `supports_store`, `developer_role` and `reasoning_effort` as unsupported.

### 2. Claude requests 404'd on the wrong path

`DEFAULT_BASE_URL` for Anthropic is `https://api.anthropic.com/v1` and the client posts to `{base}/messages`. Copilot's base URL, discovered from the `proxy-ep` field of the minted token, has no `/v1` segment, so Claude requests 404'd.

`anthropic_messages_base_url` now appends `/v1` for the Anthropic API, idempotently, so an already-suffixed base URL is left alone.

Verified against live Copilot: `/messages` returns 404, `/v1/messages` returns 200.

### 3. Models gated behind an unaccepted policy stayed invisible

Models such as Claude and Grok stay hidden from an account until their policy is accepted, so a fresh login discovered a smaller catalog than the account was entitled to. After minting the Copilot token, models whose policy state is not yet enabled are accepted, then discovery re-runs.

Supporting changes:

- Retry the model listing once on `429`, honouring `Retry-After` (capped at 10s, default 1s), because the policy updates can drain the rate-limit bucket.
- Fall back to policy-enabled model ids when the picker returns none. Some Individual accounts report `model_picker_enabled: false` for every model despite enabled policies. Limited to the public endpoint so other account types keep strict picker semantics.

Policy enablement is best-effort and never fails login, so a Copilot outage or a restrictive enterprise policy still lets a user sign in. It reports whether Copilot accepted each update, and honours the login cancellation token between models the same way the device-flow poll does.

## Notes

- `ghr_` refresh-token renewal is unchanged and still supported.
- `vscode-chat` remains the integration id.
- There is no generated Copilot catalog in this crate, so policy enablement drives off the live `/models` response rather than a static list.

## Testing

- `cargo test -p ai` — 532 passed
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets` — no warnings
- Live end-to-end against GitHub Enterprise Copilot: `claude-sonnet-5` and `claude-opus-4.8` route to `anthropic-messages`, `gpt-5.6-sol` to `openai-responses`, `gpt-4.1` and `gemini-3.7-flash` to `openai-completions`. All returned correct content, where Claude previously returned nothing.

New unit tests cover the routing rule, the idempotent `/v1` handling, the `Retry-After` clamp, the policy-fallback parsing, and the policy update result.
